### PR TITLE
Progress and cancel

### DIFF
--- a/Tests/GrepCoreTest.cs
+++ b/Tests/GrepCoreTest.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
+using dnGREP.Common;
+using dnGREP.Engines;
 using Xunit;
 using Xunit.Extensions;
-using dnGREP;
-using System.IO;
-using dnGREP.Common;
-using System.Data.Linq;
-using System.Collections;
-using System.Text.RegularExpressions;
-using System.Diagnostics;
 
 namespace Tests
 {
@@ -275,7 +273,7 @@ namespace Tests
         {
             Utils.CopyFiles(sourceFolder + "\\TestCase14", destinationFolder + "\\TestCase14", null, null);
             GrepCore core = new GrepCore();
-            core.SearchParams.VerboseMatchCount = verbose;
+            core.SearchParams = new GrepEngineInitParams(false, 0, 0, 0.5, verbose);
             Stopwatch sw = new Stopwatch();
             sw.Start();
             List<GrepSearchResult> results = core.Search(Directory.GetFiles(destinationFolder + "\\TestCase14", "*.txt"), type, "1234", option, -1);

--- a/Tests/UtilsTest.cs
+++ b/Tests/UtilsTest.cs
@@ -1,9 +1,9 @@
-﻿using dnGREP.Common;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using dnGREP.Common;
 using Xunit;
 using Xunit.Extensions;
 
@@ -926,7 +926,7 @@ namespace Tests
         [InlineData("\\TestCase11", "#!*python;#!*sh", 3)]
         public void TestAsteriskGetFilesWithoutExclude(string folder, string pattern, int expectedCount)
         {
-            var result = Utils.GetFileListEx(sourceFolder + folder, pattern, null, false, false, true, true, 0, 0, FileDateFilter.None, null, null);
+            var result = Utils.GetFileListEx(new FileFilter(sourceFolder + folder, pattern, null, false, false, true, true, 0, 0, FileDateFilter.None, null, null));
             int counter = 0;
             foreach (var f in result)
                 counter++;
@@ -942,7 +942,7 @@ namespace Tests
         public void TestAsteriskGetFilesWithExclude(string folder, string pattern, String excludePattern, int expectedCount)
         {
             // This recurses to subfolders
-            var result = Utils.GetFileListEx(sourceFolder + folder, pattern, excludePattern, false, true, true, true, 0, 0, FileDateFilter.None, null, null);
+            var result = Utils.GetFileListEx(new FileFilter(sourceFolder + folder, pattern, excludePattern, false, true, true, true, 0, 0, FileDateFilter.None, null, null));
             int counter = 0;
             foreach (var f in result)
                 counter++;

--- a/dnGREP.ArchiveEngine/GrepEngineArchive.cs
+++ b/dnGREP.ArchiveEngine/GrepEngineArchive.cs
@@ -17,8 +17,7 @@ namespace dnGREP.Engines.Archive
 		public GrepEngineArchive() : base() { }
 
 		public GrepEngineArchive(GrepEngineInitParams param)
-			:
-			base(param)
+			: base(param)
 		{}
 
 		public bool IsSearchOnly
@@ -33,7 +32,7 @@ namespace dnGREP.Engines.Archive
 			string tempFolder = Utils.FixFolderName(Utils.GetTempFolder()) + "dnGREP-Archive\\" + Utils.GetHash(file) + "\\";
             FileFilter filter = FileFilter.ChangePath(tempFolder);
 
-            // if the search pattern(s) only match archive files, need to include an 'any' file type  to search inside the archive.  
+            // if the search pattern(s) only match archive files, need to include an 'any' file type to search inside the archive.  
             // otherwise, keep the original pattern set so the user can specify what types of files to search inside the archive.
             var patterns = Utils.SplitPath(FileFilter.NamePatternToInclude).ToList();
             bool hasNonArchivePattern = patterns.Where(p => !Utils.IsArchiveExtension(Path.GetExtension(p))).Any();

--- a/dnGREP.ArchiveEngine/GrepEngineArchive.cs
+++ b/dnGREP.ArchiveEngine/GrepEngineArchive.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using NLog;
-using dnGREP.Common;
-using SevenZip;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Text;
+using dnGREP.Common;
+using NLog;
+using SevenZip;
 
 namespace dnGREP.Engines.Archive
 {
@@ -25,24 +26,22 @@ namespace dnGREP.Engines.Archive
 			get { return true; }
 		}
 
-		public string Description
-		{
-			get { return "Searches inside archive files. Archives supported include: 7z, zip, rar, gzip. Search only."; }
-		}
-
-		public List<string> SupportedFileExtensions
-		{
-			get { return new List<string> ( new string[] { "7z", "zip", "rar", "gzip" }); }
-		}
-
-
         public List<GrepSearchResult> Search(string file, string searchPattern, SearchType searchType, GrepSearchOption searchOptions, Encoding encoding)
 		{
 			List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
 			SevenZipExtractor extractor = new SevenZipExtractor(file);
-			GrepEnginePlainText plainTextEngine = new GrepEnginePlainText();
-			plainTextEngine.Initialize(new GrepEngineInitParams(showLinesInContext, linesBefore, linesAfter, fuzzyMatchThreshold, verboseMatchCount));
 			string tempFolder = Utils.FixFolderName(Utils.GetTempFolder()) + "dnGREP-Archive\\" + Utils.GetHash(file) + "\\";
+            FileFilter filter = FileFilter.ChangePath(tempFolder);
+
+            // if the search pattern(s) only match archive files, need to include an 'any' file type  to search inside the archive.  
+            // otherwise, keep the original pattern set so the user can specify what types of files to search inside the archive.
+            var patterns = Utils.SplitPath(FileFilter.NamePatternToInclude).ToList();
+            bool hasNonArchivePattern = patterns.Where(p => !Utils.IsArchiveExtension(Path.GetExtension(p))).Any();
+            if (!hasNonArchivePattern)
+            {
+                patterns.Add(FileFilter.IsRegex ? ".*" : "*.*");
+                filter = filter.ChangeIncludePattern(string.Join(";", patterns.ToArray()));
+            }
 			
 			if (Directory.Exists(tempFolder))
 				Utils.DeleteFolder(tempFolder);
@@ -50,33 +49,42 @@ namespace dnGREP.Engines.Archive
 			try
 			{
 				extractor.ExtractArchive(tempFolder);
-				foreach (string archiveFileName in Directory.GetFiles(tempFolder, "*.*", SearchOption.AllDirectories))
+                foreach (var innerFileName in Utils.GetFileListEx(filter))
 				{
-                    IGrepEngine engine = GrepEngineFactory.GetSearchEngine(archiveFileName, new GrepEngineInitParams(showLinesInContext, linesBefore, linesAfter, fuzzyMatchThreshold, verboseMatchCount));
-                    var innerFileResults = engine.Search(archiveFileName, searchPattern, searchType, searchOptions, encoding);
-					
-                    using (FileStream reader = File.Open(archiveFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                    using (StreamReader streamReader = new StreamReader(reader))
+                    IGrepEngine engine = GrepEngineFactory.GetSearchEngine(innerFileName, initParams, FileFilter);
+                    var innerFileResults = engine.Search(innerFileName, searchPattern, searchType, searchOptions, encoding);
+
+                    if (innerFileResults.Count > 0)
                     {
-                        foreach (var result in innerFileResults)
+                        using (FileStream reader = File.Open(innerFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                        using (StreamReader streamReader = new StreamReader(reader))
                         {
-                            if (!result.HasSearchResults)
-                                result.SearchResults = Utils.GetLinesEx(streamReader, result.Matches, linesBefore, linesAfter);
+                            foreach (var result in innerFileResults)
+                            {
+                                if (Utils.CancelSearch)
+                                    break;
+
+                                if (!result.HasSearchResults)
+                                    result.SearchResults = Utils.GetLinesEx(streamReader, result.Matches, initParams.LinesBefore, initParams.LinesAfter);
+                            }
                         }
+                        searchResults.AddRange(innerFileResults);
                     }
-                    searchResults.AddRange(innerFileResults);
-				}
+
+                    if (Utils.CancelSearch)
+                        break;
+                }
 
 				foreach (GrepSearchResult result in searchResults)
 				{
 					result.FileNameDisplayed = file + "\\" + result.FileNameDisplayed.Substring(tempFolder.Length);
 					result.FileNameReal = file;
 					result.ReadOnly = true;
-				}
+                }
 			}
 			catch (Exception ex)
 			{
-				logger.Log<Exception>(LogLevel.Error, "Failed to search inside archive.", ex);
+				logger.Log<Exception>(LogLevel.Error, string.Format("Failed to search inside archive '{0}'", file), ex);
 			}
 			return searchResults;
 		}

--- a/dnGREP.Common/FileFilter.cs
+++ b/dnGREP.Common/FileFilter.cs
@@ -1,0 +1,91 @@
+﻿using System;
+
+namespace dnGREP.Common
+{
+    public class FileFilter
+    {
+        public FileFilter()
+        {
+            Path = ".";
+            NamePatternToInclude = "*.*";
+        }
+
+        /// <summary>
+        /// Stores the file filter parameters 
+        /// </summary>
+        /// <param name="path">Path to one or many files separated by semi-colon or path to a folder</param>
+        /// <param name="namePatternToInclude">File name pattern. (E.g. *.cs) or regex to include. If null returns empty array. If empty string returns all files.</param>
+        /// <param name="namePatternToExclude">File name pattern. (E.g. *.cs) or regex to exclude. If null or empty is ignored.</param>
+        /// <param name="isRegex">Whether to use regex as search pattern. Otherwise use asterisks</param>
+        /// <param name="includeSubfolders">Include sub folders</param>
+        /// <param name="includeHidden">Include hidden folders</param>
+        /// <param name="includeBinary">Include binary files</param>
+        /// <param name="sizeFrom">Size in KB</param>
+        /// <param name="sizeTo">Size in KB</param>
+        /// <param name="dateFilter">Filter by file modified or created date time range</param>
+        /// <param name="startTime">start of time range</param>
+        /// <param name="endTime">end of time range</param>
+        public FileFilter(string path, string namePatternToInclude, string namePatternToExclude, bool isRegex,
+            bool includeSubfolders, bool includeHidden, bool includeBinary, int sizeFrom, int sizeTo,
+            FileDateFilter dateFilter, DateTime? startTime, DateTime? endTime)
+        {
+            Path = path;
+            NamePatternToInclude = namePatternToInclude;
+            NamePatternToExclude = namePatternToExclude;
+            IsRegex = isRegex;
+            IncludeSubfolders = includeSubfolders;
+            IncludeHidden = includeHidden;
+            IncludeBinary = includeBinary;
+            SizeFrom = sizeFrom;
+            SizeTo = sizeTo;
+            DateFilter = dateFilter;
+            StartTime = startTime;
+            EndTime = endTime;
+        }
+
+        public FileFilter ChangePath(string path)
+        {
+            var f = Clone();
+            f.Path = path;
+            return f;
+        }
+
+        public FileFilter ChangeIncludePattern(string includePattern)
+        {
+            var f = Clone();
+            f.NamePatternToInclude = includePattern;
+            return f;
+        }
+
+        public FileFilter Clone()
+        {
+            return new FileFilter(
+                Path,
+                NamePatternToInclude,
+                NamePatternToExclude,
+                IsRegex,
+                IncludeSubfolders,
+                IncludeHidden,
+                IncludeBinary,
+                SizeFrom,
+                SizeTo,
+                DateFilter,
+                StartTime,
+                EndTime
+                );
+        }
+
+        public string Path { get; private set; }
+        public string NamePatternToInclude { get; set; }
+        public string NamePatternToExclude { get; private set; }
+        public bool IsRegex { get; private set; }
+        public bool IncludeSubfolders { get; private set; }
+        public bool IncludeHidden { get; private set; }
+        public bool IncludeBinary { get; private set; }
+        public int SizeFrom { get; private set; }
+        public int SizeTo { get; private set; }
+        public FileDateFilter DateFilter { get; private set; }
+        public DateTime? StartTime { get; private set; }
+        public DateTime? EndTime { get; private set; }
+    }
+}

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -421,7 +421,10 @@ namespace dnGREP.Common
         public static bool IsArchiveExtension(string ext)
         {
             if (!string.IsNullOrWhiteSpace(ext))
-                return archiveExtensions.Contains(ext.ToLower());
+            {
+                // regex extensions may have a 'match end of line' char: remove it
+                return archiveExtensions.Contains(ext.TrimEnd('$').ToLower());
+            }
             return false;
         }
         private static List<string> archiveExtensions = new string[]

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -1,17 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.IO;
-using System.Text.RegularExpressions;
 using System.Diagnostics;
-using System.Reflection;
-using System.Net;
-using System.Xml;
-using System.Security.Permissions;
-using System.Security;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
+using System.Text;
+using System.Text.RegularExpressions;
 using NLog;
-using System.Security.AccessControl;
 
 namespace dnGREP.Common
 {
@@ -314,6 +311,38 @@ namespace dnGREP.Common
         }
 
         /// <summary>
+        /// Returns true if the source file extension is a recognized archive file
+        /// </summary>
+        /// <param name="srcFile">a file name</param>
+        /// <returns></returns>
+        public static bool IsArchive(string srcFile)
+        {
+            if (!string.IsNullOrWhiteSpace(srcFile))
+            {
+                return IsArchiveExtension(Path.GetExtension(srcFile));
+            }
+            return false;
+        }
+        
+        /// <summary>
+        /// Returns true if the parameter is a recognized archive file format file extension.
+        /// </summary>
+        /// <param name="ext">a file extension, with leading '.'</param>
+        /// <returns></returns>
+        public static bool IsArchiveExtension(string ext)
+        {
+            if (!string.IsNullOrWhiteSpace(ext))
+                return archiveExtensions.Contains(ext.ToLower());
+            return false;
+        }
+        private static List<string> archiveExtensions = new string[]
+            {
+                // this is just some of the archive formats supported by 7zip.
+                ".zip", ".rar", ".7z", ".gz", ".gzip", ".bz2", ".bzip2", ".tar", ".tbz2", ".tbz", ".tgz", ".arj", ".cab", ".cpio", 
+                ".deb", ".dmg", ".iso", ".hfs", ".hfsx", ".lzh", ".lha", ".lzma", ".z", ".taz", ".rpm", ".xar", ".pkg", ".xz", ".txz", ".zipx", ".jar", ".epub"
+            }.ToList();
+
+        /// <summary>
         /// Add DirectorySeparatorChar to the end of the folder path if does not exist
         /// </summary>
         /// <param name="name">Folder path</param>
@@ -464,35 +493,22 @@ namespace dnGREP.Common
         /// returns array of strings that contain full paths to the files.
         /// If no files found returns 0 length array.
         /// </summary>
-        /// <param name="path">Path to one or many files separated by semi-colon or path to a folder</param>
-        /// <param name="namePatternToInclude">File name pattern. (E.g. *.cs) or regex to include. If null returns empty array. If empty string returns all files.</param>
-        /// <param name="namePatternToExclude">File name pattern. (E.g. *.cs) or regex to exclude. If null or empty is ignored.</param>
-        /// <param name="isRegex">Whether to use regex as search pattern. Otherwise use asterisks</param>
-        /// <param name="includeSubfolders">Include sub folders</param>
-        /// <param name="includeHidden">Include hidden folders</param>
-        /// <param name="includeBinary">Include binary files</param>
-        /// <param name="sizeFrom">Size in KB</param>
-        /// <param name="sizeTo">Size in KB</param>
-        /// <param name="dateFilter">Filter by file modified or created date time range</param>
-        /// <param name="startTime">start of time range</param>
-        /// <param name="endTime">end of time range</param>
+        /// <param name="filter">the file filter parameters</param>
         /// <returns></returns>
-        public static IEnumerable<string> GetFileListEx(string path, string namePatternToInclude, string namePatternToExclude, bool isRegex,
-            bool includeSubfolders, bool includeHidden, bool includeBinary, int sizeFrom, int sizeTo,
-            FileDateFilter dateFilter, DateTime? startTime, DateTime? endTime)
+        public static IEnumerable<string> GetFileListEx(FileFilter filter)
         {
-            if (string.IsNullOrWhiteSpace(path) || namePatternToInclude == null)
+            if (string.IsNullOrWhiteSpace(filter.Path) || filter.NamePatternToInclude == null)
             {
                 yield break;
             }
 
             // Hash set to ensure file name uniqueness
             HashSet<string> matches = new HashSet<string>();
-            List<string> _includePatterns = new List<string>(SplitPath(namePatternToInclude));
-            List<string> _excludePatterns = new List<string>(SplitPath(namePatternToExclude));
+            List<string> _includePatterns = new List<string>(SplitPath(filter.NamePatternToInclude));
+            List<string> _excludePatterns = new List<string>(SplitPath(filter.NamePatternToExclude));
             List<Regex> includeRegexPatterns = new List<Regex>();
             List<Regex> excludeRegexPatterns = new List<Regex>();
-            if (!isRegex)
+            if (!filter.IsRegex)
             {
                 foreach (var pattern in _includePatterns) includeRegexPatterns.Add(new Regex(wildcardToRegex(pattern), RegexOptions.Compiled | RegexOptions.IgnoreCase));
                 foreach (var pattern in _excludePatterns) excludeRegexPatterns.Add(new Regex(wildcardToRegex(pattern), RegexOptions.Compiled | RegexOptions.IgnoreCase));
@@ -503,7 +519,7 @@ namespace dnGREP.Common
                 foreach (var pattern in _excludePatterns) excludeRegexPatterns.Add(new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase));
             }
 
-            foreach (var subPath in SplitPath(path))
+            foreach (var subPath in SplitPath(filter.Path))
             {
                 if (File.Exists(subPath))
                 {
@@ -518,11 +534,11 @@ namespace dnGREP.Common
                 {
                     continue;
                 }
-                foreach (var dirPath in (!includeSubfolders ? new string[] { subPath }.AsEnumerable() :
+                foreach (var dirPath in (!filter.IncludeSubfolders ? new string[] { subPath }.AsEnumerable() :
                     new string[] { subPath }.AsEnumerable().Concat(Directory.EnumerateDirectories(subPath, "*", SearchOption.AllDirectories))))
                 {
                     DirectoryInfo dirInfo = null;
-                    if (!includeHidden)
+                    if (!filter.IncludeHidden)
                     {
                         if (dirInfo == null)
                             dirInfo = new DirectoryInfo(dirPath);
@@ -538,7 +554,7 @@ namespace dnGREP.Common
                         FileInfo fileInfo = null;
                         try
                         {
-                            if (!includeHidden)
+                            if (!filter.IncludeHidden)
                             {
                                 if (fileInfo == null)
                                     fileInfo = new FileInfo(filePath);
@@ -546,34 +562,34 @@ namespace dnGREP.Common
                                     continue;
                             }
 
-                            if (!includeBinary && IsBinary(filePath))
+                            if (!IsArchive(filePath) && !filter.IncludeBinary && IsBinary(filePath))
                                 continue;
-                            if (sizeFrom > 0 || sizeTo > 0)
+                            if (filter.SizeFrom > 0 || filter.SizeTo > 0)
                             {
                                 if (fileInfo == null)
                                     fileInfo = new FileInfo(filePath);
 
                                 long sizeKB = fileInfo.Length / 1000;
-                                if (sizeFrom > 0 && sizeKB < sizeFrom)
+                                if (filter.SizeFrom > 0 && sizeKB < filter.SizeFrom)
                                 {
                                     continue;
                                 }
-                                if (sizeTo > 0 && sizeKB > sizeTo)
+                                if (filter.SizeTo > 0 && sizeKB > filter.SizeTo)
                                 {
                                     continue;
                                 }
                             }
-                            if (dateFilter != FileDateFilter.None)
+                            if (filter.DateFilter != FileDateFilter.None)
                             {
                                 if (fileInfo == null)
                                     fileInfo = new FileInfo(filePath);
 
-                                DateTime fileDate = dateFilter == FileDateFilter.Created ? fileInfo.CreationTime : fileInfo.LastWriteTime;
-                                if (startTime.HasValue && fileDate < startTime.Value)
+                                DateTime fileDate = filter.DateFilter == FileDateFilter.Created ? fileInfo.CreationTime : fileInfo.LastWriteTime;
+                                if (filter.StartTime.HasValue && fileDate < filter.StartTime.Value)
                                 {
                                     continue;
                                 }
-                                if (endTime.HasValue && fileDate >= endTime.Value)
+                                if (filter.EndTime.HasValue && fileDate >= filter.EndTime.Value)
                                 {
                                     continue;
                                 }
@@ -687,8 +703,9 @@ namespace dnGREP.Common
             bool includeSubfolders, bool includeHidden, bool includeBinary, int sizeFrom, int sizeTo,
             FileDateFilter dateFilter, DateTime? startTime, DateTime? endTime)
         {
-            return new List<string>(GetFileListEx(path, namePatternToInclude, namePatternToExclude, isRegex,
-                includeSubfolders, includeHidden, includeBinary, sizeFrom, sizeTo, dateFilter, startTime, endTime)).ToArray();
+            var filter = new FileFilter(path, namePatternToInclude, namePatternToExclude, isRegex,
+                includeSubfolders, includeHidden, includeBinary, sizeFrom, sizeTo, dateFilter, startTime, endTime);
+            return GetFileListEx(filter).ToArray();
         }
 
         /// <summary>

--- a/dnGREP.Common/dnGREP.Common.csproj
+++ b/dnGREP.Common/dnGREP.Common.csproj
@@ -116,6 +116,7 @@
     </Compile>
     <Compile Include="BookmarkLibrary.cs" />
     <Compile Include="Enums.cs" />
+    <Compile Include="FileFilter.cs" />
     <Compile Include="GrepSearchResult.cs" />
     <Compile Include="OpenFileArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/dnGREP.Engines/GrepCore.cs
+++ b/dnGREP.Engines/GrepCore.cs
@@ -1,55 +1,53 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.IO;
-using NLog;
-using System.Text.RegularExpressions;
-using System.Xml;
-using System.Xml.XPath;
-using dnGREP.Common;
+using System.Text;
 using dnGREP.Engines;
+using NLog;
 
 namespace dnGREP.Common
 {
-	public class GrepCore
-	{
-		private GrepEngineInitParams searchParams = new GrepEngineInitParams();
+    public class GrepCore
+    {
+        public GrepCore()
+        {
+            SearchParams = new GrepEngineInitParams();
+            FileFilter = new FileFilter();
+        }
 
-		public GrepEngineInitParams SearchParams
-		{
-			get { return searchParams; }
-			set { searchParams = value; }
-		}
-		
-		private static Logger logger = LogManager.GetCurrentClassLogger();
-		private List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
-		public delegate void SearchProgressHandler(object sender, ProgressStatus files);
+        public GrepEngineInitParams SearchParams { get; set; }
+        public FileFilter FileFilter { get; set; }
+
+
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+        private List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
+        public delegate void SearchProgressHandler(object sender, ProgressStatus files);
         public event SearchProgressHandler ProcessedFile = delegate { };
-		public class ProgressStatus
-		{
-			public ProgressStatus(int processed, List<GrepSearchResult> results, string fileName)
-			{
-				ProcessedFiles = processed;
-				SearchResults = results;
+        public class ProgressStatus
+        {
+            public ProgressStatus(int processed, List<GrepSearchResult> results, string fileName)
+            {
+                ProcessedFiles = processed;
+                SearchResults = results;
                 FileName = fileName;
-			}
-			public int ProcessedFiles;
-			public List<GrepSearchResult> SearchResults;
+            }
+            public int ProcessedFiles;
+            public List<GrepSearchResult> SearchResults;
             public string FileName;
-		}
-	
-		/// <summary>
-		/// Searches folder for files whose content matches regex
-		/// </summary>
-		/// <param name="files">Files to search in. If one of the files does not exist or is open, it is skipped.</param>
-		/// <param name="searchRegex">Regex pattern</param>
-		/// <returns>List of results. If nothing is found returns empty list</returns>
-		public List<GrepSearchResult> Search(IEnumerable<string> files, SearchType searchType, string searchPattern, GrepSearchOption searchOptions, int codePage)
-		{
-			List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
+        }
 
-			if (files == null)
-				return searchResults;
+        /// <summary>
+        /// Searches folder for files whose content matches regex
+        /// </summary>
+        /// <param name="files">Files to search in. If one of the files does not exist or is open, it is skipped.</param>
+        /// <param name="searchRegex">Regex pattern</param>
+        /// <returns>List of results. If nothing is found returns empty list</returns>
+        public List<GrepSearchResult> Search(IEnumerable<string> files, SearchType searchType, string searchPattern, GrepSearchOption searchOptions, int codePage)
+        {
+            List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
+
+            if (files == null)
+                return searchResults;
 
             Utils.CancelSearch = false;
 
@@ -57,8 +55,7 @@ namespace dnGREP.Common
             {
                 foreach (string file in files)
                 {
-                    string fname = file;// Path.GetFileName(file);
-                    ProcessedFile(this, new ProgressStatus(searchResults.Count, null, fname));
+                    ProcessedFile(this, new ProgressStatus(searchResults.Count, null, file));
 
                     searchResults.Add(new GrepSearchResult(file, searchPattern, null, Encoding.Default));
                     if ((searchOptions & GrepSearchOption.StopAfterFirstMatch) == GrepSearchOption.StopAfterFirstMatch)
@@ -67,10 +64,7 @@ namespace dnGREP.Common
                         break;
                 }
 
-                if (ProcessedFile != null)
-                {
-                    ProcessedFile(this, new ProgressStatus(searchResults.Count, searchResults, null));
-                }
+                ProcessedFile(this, new ProgressStatus(searchResults.Count, searchResults, null));
 
                 return searchResults;
             }
@@ -82,20 +76,18 @@ namespace dnGREP.Common
                 {
                     foreach (string file in files)
                     {
-                        string fname = file;// Path.GetFileName(file);
-                        ProcessedFile(this, new ProgressStatus(processedFiles, null, fname));
+                        ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
                         try
                         {
-                            IGrepEngine engine = GrepEngineFactory.GetSearchEngine(file, SearchParams);
+                            IGrepEngine engine = GrepEngineFactory.GetSearchEngine(file, SearchParams, FileFilter);
 
                             processedFiles++;
 
-                            Encoding encoding = null;
-                            if (codePage == -1)
-                                encoding = Utils.GetFileEncoding(file);
-                            else
+                            Encoding encoding = Encoding.Default;
+                            if (codePage > -1)
                                 encoding = Encoding.GetEncoding(codePage);
-
+                            else if (!Utils.IsBinary(file))
+                                encoding = Utils.GetFileEncoding(file);
 
                             if (Utils.CancelSearch)
                             {
@@ -109,11 +101,7 @@ namespace dnGREP.Common
                                 searchResults.AddRange(fileSearchResults);
                             }
 
-                            if (ProcessedFile != null)
-                            {
-                                ProcessedFile(this, new ProgressStatus(processedFiles, fileSearchResults, fname));
-                            }
-
+                            ProcessedFile(this, new ProgressStatus(processedFiles, fileSearchResults, file));
                         }
                         catch (Exception ex)
                         {
@@ -123,7 +111,7 @@ namespace dnGREP.Common
                             {
                                 List<GrepSearchResult> _results = new List<GrepSearchResult>();
                                 _results.Add(new GrepSearchResult(file, searchPattern, ex.Message, false));
-                                ProcessedFile(this, new ProgressStatus(processedFiles, _results, fname));
+                                ProcessedFile(this, new ProgressStatus(processedFiles, _results, file));
                             }
                         }
 
@@ -138,87 +126,85 @@ namespace dnGREP.Common
 
                 return searchResults;
             }
-		}
+        }
 
-		public int Replace(IEnumerable<string> files, SearchType searchType, string searchPattern, string replacePattern, GrepSearchOption searchOptions, int codePage)
-		{
-			string tempFolder = Utils.GetTempFolder();
+        public int Replace(IEnumerable<string> files, SearchType searchType, string searchPattern, string replacePattern, GrepSearchOption searchOptions, int codePage)
+        {
+            string tempFolder = Utils.GetTempFolder();
 
-			if (files == null || !Directory.Exists(tempFolder))
-				return 0;
+            if (files == null || !Directory.Exists(tempFolder))
+                return 0;
 
             replacePattern = Utils.ReplaceSpecialCharacters(replacePattern);
 
-			int processedFiles = 0;
+            int processedFiles = 0;
             Utils.CancelSearch = false;
             string tempFileName = null;
 
-			try
-			{
-				foreach (string file in files)
-				{
-                    string fname = file; // Path.GetFileName(file);
-                    ProcessedFile(this, new ProgressStatus(processedFiles, null, fname));
-                    
-                    tempFileName = Path.Combine(tempFolder, Path.GetFileName(file));
-					IGrepEngine engine = GrepEngineFactory.GetReplaceEngine(file, searchParams);
+            try
+            {
+                foreach (string file in files)
+                {
+                    ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
 
-					try
-					{
-						processedFiles++;
-						// Copy file					
-						Utils.CopyFile(file, tempFileName, true);
+                    tempFileName = Path.Combine(tempFolder, Path.GetFileName(file));
+                    IGrepEngine engine = GrepEngineFactory.GetReplaceEngine(file, SearchParams, FileFilter);
+
+                    try
+                    {
+                        processedFiles++;
+                        // Copy file					
+                        Utils.CopyFile(file, tempFileName, true);
                         Utils.DeleteFile(file);
 
-						Encoding encoding = null;
-						if (codePage == -1)
-							encoding = Utils.GetFileEncoding(tempFileName);
-						else
-							encoding = Encoding.GetEncoding(codePage);
-
-
-                        if (Utils.CancelSearch)
-						{
-							break;
-						}
-
-						if (!engine.Replace(tempFileName, file, searchPattern, replacePattern, searchType, searchOptions, encoding))
-						{
-							throw new ApplicationException("Replace failed for file: " + file);
-						}
-
-                        if (!Utils.CancelSearch && ProcessedFile != null)
-							ProcessedFile(this, new ProgressStatus(processedFiles, null, fname));
-
-
-						File.SetAttributes(file, File.GetAttributes(tempFileName));
+                        Encoding encoding = Encoding.Default;
+                        if (codePage > -1)
+                            encoding = Encoding.GetEncoding(codePage);
+                        else if (!Utils.IsBinary(file))
+                            encoding = Utils.GetFileEncoding(tempFileName);
 
                         if (Utils.CancelSearch)
-						{
-							// Replace the file
-							Utils.DeleteFile(file);
-							Utils.CopyFile(tempFileName, file, true);
-							break;
-						}
-					}
-					catch (Exception ex)
-					{
-						logger.Log<Exception>(LogLevel.Error, ex.Message, ex);
-						try
-						{
-							// Replace the file
-							if (File.Exists(tempFileName) && File.Exists(file))
-							{
-								Utils.DeleteFile(file);
-								Utils.CopyFile(tempFileName, file, true);
-							}
-						}
-						catch
-						{
-							// DO NOTHING
-						}
-						return -1;
-					}
+                        {
+                            break;
+                        }
+
+                        if (!engine.Replace(tempFileName, file, searchPattern, replacePattern, searchType, searchOptions, encoding))
+                        {
+                            throw new ApplicationException("Replace failed for file: " + file);
+                        }
+
+                        if (!Utils.CancelSearch)
+                            ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
+
+
+                        File.SetAttributes(file, File.GetAttributes(tempFileName));
+
+                        if (Utils.CancelSearch)
+                        {
+                            // Replace the file
+                            Utils.DeleteFile(file);
+                            Utils.CopyFile(tempFileName, file, true);
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Log<Exception>(LogLevel.Error, ex.Message, ex);
+                        try
+                        {
+                            // Replace the file
+                            if (File.Exists(tempFileName) && File.Exists(file))
+                            {
+                                Utils.DeleteFile(file);
+                                Utils.CopyFile(tempFileName, file, true);
+                            }
+                        }
+                        catch
+                        {
+                            // DO NOTHING
+                        }
+                        return -1;
+                    }
                     finally
                     {
                         try
@@ -231,34 +217,34 @@ namespace dnGREP.Common
                             // DO NOTHING
                         }
                     }
-				}
-			}
-			finally
-			{
-				GrepEngineFactory.UnloadEngines();
-			}
+                }
+            }
+            finally
+            {
+                GrepEngineFactory.UnloadEngines();
+            }
 
-			return processedFiles;
-		}
+            return processedFiles;
+        }
 
-		public bool Undo(string folderPath)
-		{
-			string tempFolder = Utils.GetTempFolder();
-			if (!Directory.Exists(tempFolder))
-			{
-				logger.Error("Failed to undo replacement as temporary directory was removed.");
-				return false;
-			}
-			try
-			{
-				Utils.CopyFiles(tempFolder, folderPath, null, null);
-				return true;
-			}
-			catch (Exception ex)
-			{
-				logger.Log<Exception>(LogLevel.Error, "Failed to undo replacement", ex);
-				return false;
-			}
-		}		
-	}
+        public bool Undo(string folderPath)
+        {
+            string tempFolder = Utils.GetTempFolder();
+            if (!Directory.Exists(tempFolder))
+            {
+                logger.Error("Failed to undo replacement as temporary directory was removed.");
+                return false;
+            }
+            try
+            {
+                Utils.CopyFiles(tempFolder, folderPath, null, null);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Log<Exception>(LogLevel.Error, "Failed to undo replacement", ex);
+                return false;
+            }
+        }
+    }
 }

--- a/dnGREP.Engines/GrepEngineBase.cs
+++ b/dnGREP.Engines/GrepEngineBase.cs
@@ -393,12 +393,16 @@ namespace dnGREP.Engines
 
 			List<GrepSearchResult.GrepLine> results = new List<GrepSearchResult.GrepLine>();
             List<GrepSearchResult.GrepMatch> globalMatches = new List<GrepSearchResult.GrepMatch>();
-            foreach (Match match in Regex.Matches(text, searchPattern, regexOptions))
+            var matches = Regex.Matches(text, searchPattern, regexOptions);
+            foreach (Match match in matches)
 			{
                 if (verboseMatchCount && lineEndIndexes.Count > 0)
                     lineNumber = lineEndIndexes.FindIndex(i => i > match.Index) + 1;
 
                 globalMatches.Add(new GrepSearchResult.GrepMatch(lineNumber, match.Index, match.Length));
+
+                if (Utils.CancelSearch)
+                    break;
 			}
 
             return globalMatches;
@@ -441,7 +445,10 @@ namespace dnGREP.Engines
                     globalMatches.Add(new GrepSearchResult.GrepMatch(lineNumber, index, searchText.Length));
 					index++;
 				}
-			}
+
+                if (Utils.CancelSearch)
+                    break;
+            }
 
             return globalMatches;
 		}
@@ -472,7 +479,10 @@ namespace dnGREP.Engines
                     globalMatches.Add(new GrepSearchResult.GrepMatch(lineNumber, index, searchText.Length));
 					index++;
 				}
-			}
+
+                if (Utils.CancelSearch)
+                    break;
+            }
 
             return globalMatches;
 		}
@@ -502,7 +512,10 @@ namespace dnGREP.Engines
 			
 					index++;
 				}
-			}
+
+                if (Utils.CancelSearch)
+                    break;
+            }
 			sb.Append(text.Substring(counter));
 			return sb.ToString();
 		}
@@ -532,7 +545,10 @@ namespace dnGREP.Engines
 
 					index++;
 				}
-			}
+
+                if (Utils.CancelSearch)
+                    break;
+            }
 			sb.Append(text.Substring(counter));
 			return sb.ToString();
 		}

--- a/dnGREP.Engines/GrepEngineFactory.cs
+++ b/dnGREP.Engines/GrepEngineFactory.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using System.IO;
+using System.Text;
 using dnGREP.Common;
-using System.Reflection;
 using NLog;
 
 namespace dnGREP.Engines
@@ -42,8 +42,11 @@ namespace dnGREP.Engines
             }
         }
 
-        public static IGrepEngine GetSearchEngine(string fileName, GrepEngineInitParams param)
+        public static IGrepEngine GetSearchEngine(string fileName, GrepEngineInitParams param, FileFilter filter)
         {
+            Debug.Assert(param != null);
+            Debug.Assert(filter != null);
+
             loadPlugins();
 
             string fileExtension = Path.GetExtension(fileName).ToLower();
@@ -61,13 +64,13 @@ namespace dnGREP.Engines
                 }
             }
             GrepEnginePlainText plainTextEngine = new GrepEnginePlainText();
-            plainTextEngine.Initialize(param);
+            plainTextEngine.Initialize(param, filter);
 
             if (fileTypeEngines.ContainsKey(fileExtension) && fileTypeEngines[fileExtension].Enabled)
             {
                 if (FrameworkVersionsAreCompatible(fileTypeEngines[fileExtension].Engine.FrameworkVersion, plainTextEngine.FrameworkVersion))
                 {
-                    if (fileTypeEngines[fileExtension].Engine.Initialize(param))
+                    if (fileTypeEngines[fileExtension].Engine.Initialize(param, filter))
                     {
                         return fileTypeEngines[fileExtension].Engine;
                     }
@@ -95,7 +98,7 @@ namespace dnGREP.Engines
             return ( version1.Major == version2.Major );
         }
 
-        public static IGrepEngine GetReplaceEngine(string fileName, GrepEngineInitParams param)
+        public static IGrepEngine GetReplaceEngine(string fileName, GrepEngineInitParams param, FileFilter filter)
         {
             loadPlugins();
 
@@ -114,13 +117,13 @@ namespace dnGREP.Engines
                 }
             }
             GrepEnginePlainText plainTextEngine = new GrepEnginePlainText();
-            plainTextEngine.Initialize(param);
+            plainTextEngine.Initialize(param, filter);
 
             if (fileTypeEngines.ContainsKey(fileExtension) && fileTypeEngines[fileExtension].Enabled && !fileTypeEngines[fileExtension].Engine.IsSearchOnly)
             {
                 if (FrameworkVersionsAreCompatible(fileTypeEngines[fileExtension].Engine.FrameworkVersion, plainTextEngine.FrameworkVersion) )
                 {
-                    if (fileTypeEngines[fileExtension].Engine.Initialize(param))
+                    if (fileTypeEngines[fileExtension].Engine.Initialize(param, filter))
                     {
                         return fileTypeEngines[fileExtension].Engine;
                     }

--- a/dnGREP.Engines/GrepEnginePlainText.cs
+++ b/dnGREP.Engines/GrepEnginePlainText.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Text;
 using dnGREP.Common;
-using System.IO;
 using NLog;
-using System.Reflection;
 
 namespace dnGREP.Engines
 {
@@ -17,16 +17,6 @@ namespace dnGREP.Engines
         public bool IsSearchOnly
         {
             get { return false; }
-        }
-
-        public string Description
-        {
-            get { return "Basic engine for searching plain text file"; }
-        }
-
-        public List<string> SupportedFileExtensions
-        {
-            get { return new List<string>(new string[] { "*" }); }
         }
 
         public List<GrepSearchResult> Search(string file, string searchPattern, SearchType searchType, GrepSearchOption searchOptions, Encoding encoding)

--- a/dnGREP.Engines/IGrepEngine.cs
+++ b/dnGREP.Engines/IGrepEngine.cs
@@ -2,28 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using dnGREP.Common;
-using dnGREP.Engines;
 
 namespace dnGREP.Engines
 {
 	public interface IGrepEngine
 	{
-		bool Initialize(GrepEngineInitParams param);
+		bool Initialize(GrepEngineInitParams param, FileFilter filter);
 
 		/// <summary>
 		/// Return true if engine supports search only. Return false is engine supports replace as well.
 		/// </summary>
 		bool IsSearchOnly { get;}
 
-		/// <summary>
-		/// Short description of engine
-		/// </summary>
-		string Description { get;}
-
-		/// <summary>
-		/// List of file extensions that the engine will work with
-		/// </summary>
-		List<string> SupportedFileExtensions { get;}
+        FileFilter FileFilter { get; }
 
 		/// <summary>
 		/// Searches folder for files whose content matches regex

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -735,13 +735,18 @@ namespace dnGREP.WPF
                     GrepCore.ProgressStatus progress = (GrepCore.ProgressStatus)e.UserState;
                     string result = string.Empty;
                     if (progress.SearchResults != null)
-                    {
-                        SearchResults.AddRange(progress.SearchResults);
-                        result = string.Format("Searched {0} files. Found {1} matching files.", progress.ProcessedFiles, SearchResults.Count);
+                    {SearchResults.AddRange(progress.SearchResults);
+                        if (!string.IsNullOrWhiteSpace(progress.FileName))
+                            result = string.Format("Searched {0} files. Found {1} matching files - processing {2}", progress.ProcessedFiles, SearchResults.Count, progress.FileName);
+                        else
+                            result = string.Format("Searched {0} files. Found {1} matching files.", progress.ProcessedFiles, SearchResults.Count);
                     }
                     else
                     {
-                        result = string.Format("Searched {0} files.", progress.ProcessedFiles);
+                        if (!string.IsNullOrWhiteSpace(progress.FileName))
+                            result = string.Format("Searched {0} files - processing {1}", progress.ProcessedFiles, progress.FileName);
+                        else
+                            result = string.Format("Searched {0} files.", progress.ProcessedFiles);
                     }
 
                     StatusMessage = result;

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -463,7 +463,7 @@ namespace dnGREP.WPF
 
                 FormattedGrepResult result = selectedNode.Parent;
                 OpenFileArgs fileArg = new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs));
-                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, new GrepEngineInitParams(false, 0, 0, 0.5, false)).OpenFile(fileArg);
+                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, new GrepEngineInitParams(false, 0, 0, 0.5, false), new FileFilter()).OpenFile(fileArg);
                 if (fileArg.UseBaseEngine)
                     Utils.OpenFile(new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs)));
             }
@@ -484,7 +484,7 @@ namespace dnGREP.WPF
                 // Line was selected
                 int lineNumber = 0;
                 OpenFileArgs fileArg = new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs));
-                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, new GrepEngineInitParams(false, 0, 0, 0.5, false)).OpenFile(fileArg);
+                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, new GrepEngineInitParams(false, 0, 0, 0.5, false), new FileFilter()).OpenFile(fileArg);
                 if (fileArg.UseBaseEngine)
                     Utils.OpenFile(new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs)));
             }
@@ -625,14 +625,16 @@ namespace dnGREP.WPF
 
                         Utils.CancelSearch = false;
 
+                        FileFilter fileParams = new FileFilter(FileOrFolderPath, filePatternInclude, filePatternExclude, param.TypeOfFileSearch == FileSearchType.Regex, param.IncludeSubfolder,
+                                param.IncludeHidden, param.IncludeBinary, sizeFrom, sizeTo, param.UseFileDateFilter, startTime, endTime);
+
                         if (param.CurrentGrepOperation == GrepOperation.SearchInResults)
                         {
                             files = (List<string>)workerParams["Files"];
                         }
                         else
                         {
-                            files = Utils.GetFileListEx(FileOrFolderPath, filePatternInclude, filePatternExclude, param.TypeOfFileSearch == FileSearchType.Regex, param.IncludeSubfolder,
-                                param.IncludeHidden, param.IncludeBinary, sizeFrom, sizeTo, param.UseFileDateFilter, startTime, endTime);
+                            files = Utils.GetFileListEx(fileParams);
                         }
 
                         if (Utils.CancelSearch)
@@ -656,11 +658,16 @@ namespace dnGREP.WPF
                         }
 
                         GrepCore grep = new GrepCore();
-                        grep.SearchParams.FuzzyMatchThreshold = settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold);
-                        grep.SearchParams.LinesBefore = settings.Get<int>(GrepSettings.Key.ContextLinesBefore);
-                        grep.SearchParams.LinesAfter = settings.Get<int>(GrepSettings.Key.ContextLinesAfter);
-                        grep.SearchParams.ShowLinesInContext = settings.Get<bool>(GrepSettings.Key.ShowLinesInContext);
-                        grep.SearchParams.VerboseMatchCount = settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount);
+                        grep.SearchParams = new GrepEngineInitParams(
+                            settings.Get<bool>(GrepSettings.Key.ShowLinesInContext),
+                            settings.Get<int>(GrepSettings.Key.ContextLinesBefore),
+                            settings.Get<int>(GrepSettings.Key.ContextLinesAfter),
+                            settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
+                            settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount));
+
+                        grep.FileFilter = new FileFilter(FileOrFolderPath, filePatternInclude, filePatternExclude, 
+                            param.TypeOfFileSearch == FileSearchType.Regex, param.IncludeSubfolder, param.IncludeHidden, 
+                            param.IncludeBinary, sizeFrom, sizeTo, param.UseFileDateFilter, startTime, endTime);
 
                         GrepSearchOption searchOptions = GrepSearchOption.None;
                         if (Multiline)
@@ -681,11 +688,12 @@ namespace dnGREP.WPF
                     else
                     {
                         GrepCore grep = new GrepCore();
-                        grep.SearchParams.FuzzyMatchThreshold = settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold);
-                        grep.SearchParams.LinesBefore = settings.Get<int>(GrepSettings.Key.ContextLinesBefore);
-                        grep.SearchParams.LinesAfter = settings.Get<int>(GrepSettings.Key.ContextLinesAfter);
-                        grep.SearchParams.ShowLinesInContext = settings.Get<bool>(GrepSettings.Key.ShowLinesInContext);
-                        grep.SearchParams.VerboseMatchCount = settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount);
+                        grep.SearchParams = new GrepEngineInitParams(
+                            settings.Get<bool>(GrepSettings.Key.ShowLinesInContext),
+                            settings.Get<int>(GrepSettings.Key.ContextLinesBefore),
+                            settings.Get<int>(GrepSettings.Key.ContextLinesAfter),
+                            settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
+                            settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount));
 
                         GrepSearchOption searchOptions = GrepSearchOption.None;
                         if (Multiline)
@@ -864,6 +872,12 @@ namespace dnGREP.WPF
         {
             if (CurrentGrepOperation == GrepOperation.None && !workerSearchReplace.IsBusy)
             {
+                if (TypeOfFileSearch == FileSearchType.Regex)
+                {
+                    if (!ValidateFilePatterns())
+                        return;
+                }
+
                 if (SearchInResultsContent && CanSearchInResults)
                     CurrentGrepOperation = GrepOperation.SearchInResults;
                 else
@@ -882,6 +896,52 @@ namespace dnGREP.WPF
                 workerParames["State"] = this;
                 workerSearchReplace.RunWorkerAsync(workerParames);
                 updateBookmarks();
+            }
+        }
+
+        private bool ValidateFilePatterns()
+        {
+            if (!string.IsNullOrWhiteSpace(FilePattern))
+            {
+                foreach (string pattern in Utils.SplitPath(FilePattern))
+                {
+                    string msg = ValidateRegex(pattern);
+                    if (!string.IsNullOrWhiteSpace(msg))
+                    {
+                        MessageBox.Show(string.Format("The file pattern '{0}' is not a valid regular expression:{1}{2}", pattern, Environment.NewLine, msg),
+                            "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return false;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(FilePatternIgnore))
+            {
+                foreach (string pattern in Utils.SplitPath(FilePatternIgnore))
+                {
+                    string msg = ValidateRegex(pattern);
+                    if (!string.IsNullOrWhiteSpace(msg))
+                    {
+                        MessageBox.Show(string.Format("The file pattern '{0}' is not a valid regular expression:{1}{2}", pattern, Environment.NewLine, msg),
+                            "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private string ValidateRegex(string FilePattern)
+        {
+            try
+            {
+                Regex regex = new Regex(FilePattern);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
             }
         }
 

--- a/dnGREP.WPF/ViewModels/TestPatternViewModel.cs
+++ b/dnGREP.WPF/ViewModels/TestPatternViewModel.cs
@@ -1,18 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
-using dnGREP.Common;
-using System.Collections.Specialized;
-using System.Windows.Threading;
-using System.Threading;
-using System.ComponentModel;
-using System.Windows.Media;
-using System.Windows.Input;
-using dnGREP.Engines;
-using System.IO;
 using System.Windows.Documents;
+using System.Windows.Input;
+using dnGREP.Common;
+using dnGREP.Engines;
 
 namespace dnGREP.WPF
 {
@@ -118,11 +113,13 @@ namespace dnGREP.WPF
             if (SampleText == null)
                 SampleText = string.Empty;
             GrepEnginePlainText engine = new GrepEnginePlainText();
-            engine.Initialize(new GrepEngineInitParams(GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowLinesInContext),
+            engine.Initialize(new GrepEngineInitParams(
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowLinesInContext),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter),
                 GrepSettings.Instance.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
-                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)));
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)),
+                new FileFilter());
             List<GrepSearchResult> results = new List<GrepSearchResult>();
             GrepSearchOption searchOptions = GrepSearchOption.None;
             if (Multiline)
@@ -182,11 +179,13 @@ namespace dnGREP.WPF
         private void replace()
         {
             GrepEnginePlainText engine = new GrepEnginePlainText();
-            engine.Initialize(new GrepEngineInitParams(GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowLinesInContext),
+            engine.Initialize(new GrepEngineInitParams(
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowLinesInContext),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter),
                 GrepSettings.Instance.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
-                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)));
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)),
+                new FileFilter());
             List<GrepSearchResult> results = new List<GrepSearchResult>();
 
             GrepSearchOption searchOptions = GrepSearchOption.None;

--- a/dnGREP.WordEngine/GrepEngineWord.cs
+++ b/dnGREP.WordEngine/GrepEngineWord.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
-using dnGREP.Engines;
-using NLog;
-using dnGREP.Common;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.IO;
-using System.Text.RegularExpressions;
+using System.Text;
+using dnGREP.Common;
+using NLog;
 
 namespace dnGREP.Engines.Word
 {
@@ -82,16 +80,6 @@ namespace dnGREP.Engines.Word
 			get { return true; }
 		}
 
-		public string Description
-		{
-			get { return "Searches inside Microsoft Word files. File types supported include: doc, docx. Search only."; }
-		}
-
-		public List<string> SupportedFileExtensions
-		{
-			get { return new List<string> ( new string[] { "doc", "docx" }); }
-		}
-
         public List<GrepSearchResult> Search(string file, string searchPattern, SearchType searchType, GrepSearchOption searchOptions, Encoding encoding)
 		{
 			load();
@@ -147,7 +135,7 @@ namespace dnGREP.Engines.Word
                         GrepSearchResult result = new GrepSearchResult(file, searchPattern, lines, Encoding.Default);
                         using (StringReader reader = new StringReader(text.ToString()))
                         {
-                            result.SearchResults = Utils.GetLinesEx(reader, result.Matches, linesBefore, linesAfter);
+                            result.SearchResults = Utils.GetLinesEx(reader, result.Matches, initParams.LinesBefore, initParams.LinesAfter);
                         }
 					    result.ReadOnly = true;
 					    searchResults.Add(result);
@@ -219,7 +207,7 @@ namespace dnGREP.Engines.Word
 				logger.Log<Exception>(LogLevel.Error, "Failed to load Word and create Document.", ex);
 			}
 
-            base.Initialize(new GrepEngineInitParams(showLinesInContext, linesBefore, linesAfter, fuzzyMatchThreshold, verboseMatchCount));
+            base.Initialize(initParams, FileFilter);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Update for issues:
#188 include/ignore patterns inside file archive searches
#193 show current file being searched - now shown in the status bar while search is in progress
#203 can't stop search: added more checks for stop while search is in progress.  However, there are a couple places that can't be interrupted and may take a long time to complete.  These include expanding an archive file and some regular express searches where there are many matches on one line.