### PR TITLE
Fix for Issue #269 installer is missing Newtonsoft.json library

### DIFF
--- a/dnGREP.Setup/Fragments/AppFragment.wxs
+++ b/dnGREP.Setup/Fragments/AppFragment.wxs
@@ -34,6 +34,11 @@
           <netfx:NativeImage Id="ngen_ICSharpCode.AvalonEdit.dll" Platform="$(var.NGenPlatform)" Priority="0" AppBaseDirectory="INSTALLDIR"/>
         </File>
       </Component>
+      <Component Id="cmp0459596434A34BA899AD1B009417DEEB" Guid="{6F88374E-BF90-4B91-8F7C-97B5D72E108F}">
+        <File Id="fil32F44C517B3F47268E1399A302DA7F90" KeyPath="yes" Source="$(var.dnGREP.WPF.TargetDir)\Newtonsoft.Json.dll" >
+          <netfx:NativeImage Id="ngen_Newtonsoft.Json.dll" Platform="$(var.NGenPlatform)" Priority="0" AppBaseDirectory="INSTALLDIR"/>
+        </File>
+      </Component>
       <Component Id="cmp770B497917674F316826C902746C0409" Guid="{C4E32F77-F28D-468F-8F04-A0F508915218}">
         <File Id="filB9D0C89E2BE03F54B6210850B37C7B82" KeyPath="yes" Source="$(var.dnGREP.WPF.TargetDir)\NLog.dll" >
           <netfx:NativeImage Id="ngen_NLog.dll" Platform="$(var.NGenPlatform)" Priority="0" AppBaseDirectory="INSTALLDIR"/>
@@ -54,6 +59,7 @@
       <ComponentRef Id="cmpE75E380769873171E1689F576B0BBBD1" />
       <ComponentRef Id="cmp3C0B9E685307149FAB49326CFDE9664B" />
       <ComponentRef Id="cmp0E16CB47C3F6B22E2FFDD2CC515AD1C8" />
+      <ComponentRef Id="cmp0459596434A34BA899AD1B009417DEEB" />
       <ComponentRef Id="cmp770B497917674F316826C902746C0409" />
       <ComponentRef Id="cmp63940A2343725017B4AC8FB8CA506996" />
     </ComponentGroup>


### PR DESCRIPTION
@JVimes - I modified the AppFragment.wxs manually, adding a component for Newtonsoft.Json with new unique IDs for the component id, file id and component Guid.   I did not understand how to run (or in what context) heat.exe.   I built the installer and tested it on my dev box.  If you want to run heat.exe, feel free to close this pull request.