### PR TITLE
Automatically select the "Search for" text on windows load

### DIFF
--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -7,7 +7,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         mc:Ignorable="d"
-        Title="{Binding WindowTitle}" MinWidth="485" MinHeight="485" WindowState="Normal"
+        Title="{Binding WindowTitle}" MinWidth="500" MinHeight="485" WindowState="Normal"
         Icon="/dnGREP;component/nGREP.ico" 
         Closing="MainForm_Closing" Loaded="Window_Loaded" Activated="Window_Activated" StateChanged="Window_StateChanged"
         SnapsToDevicePixels="True" ResizeMode="CanResizeWithGrip" AllowDrop="False"
@@ -25,7 +25,7 @@
     </Window.Background>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding CloseCommand}"/>
-        <KeyBinding Key="S" Command="{Binding ToggleFileOptionsCommand}" Modifiers="Alt" />
+        <KeyBinding Key="e" Command="{Binding ToggleFileOptionsCommand}" Modifiers="Alt" />
     </Window.InputBindings>
     <DockPanel ManipulationBoundaryFeedback="ManipulationBoundaryFeedbackHandler">
         <DockPanel DockPanel.Dock="Top" Margin="5,5,5,-2">
@@ -82,7 +82,7 @@
                         <!--{Binding IsFiltersExpanded}-->
                         <Expander.Header>
                             <StackPanel Margin="0,6" Orientation="Horizontal">
-                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="Search Options"/>
+                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="More ..."/>
                                 <TextBlock Margin="12,0,0,0" Text="{Binding FileFiltersSummary}" Foreground="DimGray"
                                            MaxWidth="{Binding Path=ActualWidth, ElementName=SearchText}" TextTrimming="CharacterEllipsis"/>
                             </StackPanel>
@@ -90,13 +90,13 @@
                         <GroupBox>
                             <WrapPanel SizeChanged="WrapPanel_SizeChanged">
                                 <!-- left -->
-                                <StackPanel x:Name="LeftFileOptions" Margin="3,5,15,3">
-                                    <RadioButton GroupName="SizeFilter" Margin="3" Name="rbFilterAllSizes" TabIndex="20" Content="All sizes"
+                                <StackPanel x:Name="LeftFileOptions" Margin="3,5,15,0">
+                                    <RadioButton GroupName="SizeFilter" Margin="3,0,3,3" Name="rbFilterAllSizes" TabIndex="20" Content="All sizes"
                                                  IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=No}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     <StackPanel Orientation="Horizontal">
-                                        <RadioButton GroupName="SizeFilter" Margin="3" VerticalAlignment="Center" Name="rbFilterSpecificSize" TabIndex="21" Content="Size is"
+                                        <RadioButton GroupName="SizeFilter" Margin="3,0,3,3" VerticalAlignment="Center" Name="rbFilterSpecificSize" TabIndex="21" Content="Size is"
                                                      IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=Yes}" VerticalContentAlignment="Center"/>
-                                        <TextBox Width="48" Margin="3" Name="tbFileSizeFrom" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="22"
+                                        <TextBox Width="48" Margin="3,0,3,3" Name="tbFileSizeFrom" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="22"
                                                  GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" Height="24">
                                             <TextBox.Text>
                                                 <Binding Path="SizeFrom" UpdateSourceTrigger="PropertyChanged">
@@ -106,7 +106,7 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Margin="3" VerticalAlignment="Center">to</TextBlock>
+                                        <TextBlock Margin="3,0,3,3" VerticalAlignment="Center">to</TextBlock>
                                         <TextBox Width="48" Margin="3" Name="tbFileSizeTo" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="23"
                                                  GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center">
                                             <TextBox.Text>
@@ -117,20 +117,20 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Margin="3" VerticalAlignment="Center">KB</TextBlock>
+                                        <TextBlock Margin="3,0,3,3" VerticalAlignment="Center">KB</TextBlock>
                                     </StackPanel>
-                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeSubfolder}" Name="cbIncludeSubfolders" TabIndex="24" Content="Include subfolders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeHidden}" Name="cbIncludeHiddenFolders" TabIndex="25" Content="Include hidden folders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeBinary}" Name="cbIncludeBinary" TabIndex="26" Content="Include binary files" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <CheckBox Margin="3,0,3,3" IsChecked="{Binding Path=IncludeSubfolder}" Name="cbIncludeSubfolders" TabIndex="24" Content="Include subfolders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <CheckBox Margin="3,0,3,3" IsChecked="{Binding Path=IncludeHidden}" Name="cbIncludeHiddenFolders" TabIndex="25" Content="Include hidden folders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <CheckBox Margin="3,0,3,3" IsChecked="{Binding Path=IncludeBinary}" Name="cbIncludeBinary" TabIndex="26" Content="Include binary files" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                 </StackPanel>
                                 <!-- middle -->
                                 <StackPanel x:Name="MiddleFileOptions" Orientation="Vertical" VerticalAlignment="Top" Margin="3,5,15,3">
                                     <StackPanel Orientation="Horizontal" Margin="-6,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                        <RadioButton GroupName="DateFilter" Margin="3" Content="All dates" TabIndex="30"
+                                        <RadioButton GroupName="DateFilter" Margin="3,0,3,3" Content="All dates" TabIndex="30"
                                                      IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=None}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <RadioButton GroupName="DateFilter" Margin="3" Content="Modified" TabIndex="31"
+                                        <RadioButton GroupName="DateFilter" Margin="3,0,3,3" Content="Modified" TabIndex="31"
                                                      IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Modified}" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
-                                        <RadioButton GroupName="DateFilter" Margin="3" Content="Created" TabIndex="32"
+                                        <RadioButton GroupName="DateFilter" Margin="3,0,3,3" Content="Created" TabIndex="32"
                                                      IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Created}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </StackPanel>
                                     <Grid>
@@ -142,17 +142,17 @@
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
-                                        <RadioButton GroupName="TimeRange" Grid.Row="0" Grid.Column="0" Margin="3,6" VerticalAlignment="Center" Content="From"
+                                        <RadioButton GroupName="TimeRange" Grid.Row="0" Grid.Column="0" Margin="3,0,3,6" VerticalAlignment="Center" Content="From"
                                                      IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Dates}"
                                                      IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="33" VerticalContentAlignment="Center"/>
-                                        <DatePicker Grid.Row="0" Grid.Column="1" Margin="3,2" Width="112" TabIndex="34" ToolTip="from the start of the day"
+                                        <DatePicker Grid.Row="0" Grid.Column="1" Margin="3,0,3,2" Width="112" TabIndex="34" ToolTip="from the start of the day"
                                                     CalendarStyle="{StaticResource CalendarStyle}"
                                                     DisplayDate="{x:Static sys:DateTime.Now}"
                                                     DisplayDateStart="{Binding MinStartDate}"
                                                     SelectedDate="{Binding StartDate}"
                                                     IsEnabled="{Binding IsDatesRangeSet}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="20,6,0,6" HorizontalAlignment="Left" VerticalAlignment="Center" Text="To"/>
-                                        <DatePicker Grid.Row="1" Grid.Column="1" Margin="3,2" Width="112" TabIndex="35" ToolTip="through the end of the day"
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="20,0,0,6" HorizontalAlignment="Left" VerticalAlignment="Center" Text="To"/>
+                                        <DatePicker Grid.Row="1" Grid.Column="1" Margin="3,0,3,2" Width="112" TabIndex="35" ToolTip="through the end of the day"
                                                     CalendarStyle="{StaticResource CalendarStyle}"
                                                     DisplayDateStart="{Binding MinEndDate}"
                                                     DisplayDate="{x:Static sys:DateTime.Now}"
@@ -160,15 +160,15 @@
                                                     IsEnabled="{Binding IsDatesRangeSet}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"/>
                                     </Grid>
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                        <RadioButton GroupName="TimeRange" Margin="3" VerticalAlignment="Center" Content="Past"
+                                        <RadioButton GroupName="TimeRange" Margin="3,0,3,3" VerticalAlignment="Center" Content="Past"
                                                      IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Hours}"
                                                      IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="36" VerticalContentAlignment="Center"/>
-                                        <TextBox Width="45" Margin="9,3,3,3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="37"
+                                        <TextBox Width="45" Margin="9,0,3,3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="37"
                                                  GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting"
                                                  Text="{Binding HoursFrom, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" Height="24"/>
 
-                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="to" HorizontalAlignment="Center"/>
-                                        <TextBox Width="45" Margin="3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="38"
+                                        <TextBlock Margin="3,0,3,3" VerticalAlignment="Center" Text="to" HorizontalAlignment="Center"/>
+                                        <TextBox Width="45" Margin="3,0,3,3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="38"
                                                  GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" VerticalAlignment="Center" HorizontalAlignment="Center" Height="24">
                                             <TextBox.Text>
                                                 <Binding Path="HoursTo" UpdateSourceTrigger="PropertyChanged">
@@ -178,7 +178,7 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="hours" HorizontalAlignment="Center"/>
+                                        <TextBlock Margin="3,0,3,3" VerticalAlignment="Center" Text="hours" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </StackPanel>
                                 <Border x:Name="SpacerFileOptions"/>
@@ -196,27 +196,27 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel  Grid.Row="0" Grid.Column="1" Margin="3,0" HorizontalAlignment="Right">
                                         <StackPanel Orientation="Horizontal">
-                                            <RadioButton GroupName="FileSearchType" Margin="3" Name="rbFileRegex" TabIndex="40" Content="Regex"
+                                            <RadioButton GroupName="FileSearchType" Margin="3,0,3,3" Name="rbFileRegex" TabIndex="40" Content="Regex"
                                                          IsChecked="{Binding Path=TypeOfFileSearch, Converter={StaticResource ebc}, ConverterParameter=Regex}" 
                                                          ToolTip="e.g. file[0-9]{1,2}\\.txt" VerticalContentAlignment="Center" VerticalAlignment="Center" />
-                                            <RadioButton GroupName="FileSearchType" Margin="3" Name="rbFileAsterisk" TabIndex="41" Content="Asterisk pattern"
+                                            <RadioButton GroupName="FileSearchType" Margin="3,0,3,3" Name="rbFileAsterisk" TabIndex="41" Content="Asterisk pattern"
                                                          IsChecked="{Binding Path=TypeOfFileSearch, Converter={StaticResource ebc}, ConverterParameter=Asterisk}" 
                                                          ToolTip="e.g. file??.*" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
                                         </StackPanel>
                                     </StackPanel>
                                     <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="3">
-                                        <TextBlock VerticalAlignment="Center" Margin="3" Text="Encoding:" HorizontalAlignment="Left" />
-                                        <ComboBox Width="224" Name="cbEncoding" TabIndex="42" Margin="3"
+                                        <TextBlock VerticalAlignment="Center" Margin="3,0,3,3" Text="Encoding:" HorizontalAlignment="Left" />
+                                        <ComboBox Width="224" Name="cbEncoding" TabIndex="42" Margin="3,0,3,3"
                                               DisplayMemberPath="Key" SelectedValuePath="Value" ItemsSource="{Binding Path=Encodings}"
                                               VerticalAlignment="Center" SelectedValue="{Binding Path=CodePage}" Initialized="cbEncoding_Initialized" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24" />
                                     </StackPanel>
                                     <UniformGrid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="4,3,3,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
-                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </UniformGrid>
-                                    <Button Content="Reset Options" Margin="3" Command="{Binding ResetOptionsCommand}" TabIndex="46" Height="24" Grid.Row="3" Width="98" Grid.Column="1" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
+                                    <Button Content="Reset Options" Margin="3,0,3,3" Command="{Binding ResetOptionsCommand}" TabIndex="46" Height="24" Grid.Row="3" Width="98" Grid.Column="1" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
                                 </Grid>
                             </WrapPanel>
                         </GroupBox>

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -7,12 +7,12 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         mc:Ignorable="d"
-        Title="{Binding WindowTitle}" MinWidth="500" MinHeight="460" WindowState="Normal" d:DesignWidth="900"
+        Title="{Binding WindowTitle}" MinWidth="791" MinHeight="470" WindowState="Normal" d:DesignWidth="785"
         Icon="/dnGREP;component/nGREP.ico" 
         Closing="MainForm_Closing" Loaded="Window_Loaded" Activated="Window_Activated" StateChanged="Window_StateChanged"
         SnapsToDevicePixels="True" ResizeMode="CanResizeWithGrip" AllowDrop="False"
         my:DiginesisHelpProvider.HelpKeyword="Search-Window" my:DiginesisHelpProvider.HelpNavigator="Topic" my:DiginesisHelpProvider.ShowHelp="True" 
-        WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}">
+        WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}" Width="Auto">
     <Window.Resources>
         <my:InverseBooleanConverter x:Key="InverseBooleanConverter" />
         <my:TotalValueConverter x:Key="TotalValueConverter" />
@@ -25,9 +25,8 @@
     </Window.Background>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding CloseCommand}"/>
-        <KeyBinding Key="F" Modifiers="Alt" Command="{Binding ToggleFileOptionsCommand}" />
+        <KeyBinding Key="S" Command="{Binding ToggleFileOptionsCommand}" Modifiers="Alt" />
     </Window.InputBindings>
-
     <DockPanel ManipulationBoundaryFeedback="ManipulationBoundaryFeedbackHandler">
         <DockPanel DockPanel.Dock="Top" Margin="5,5,5,-2">
             <TextBlock DockPanel.Dock="Left" FontSize="16" FontWeight="DemiBold" Text="dnGrep"/>
@@ -37,10 +36,10 @@
                         <Setter Property="Height" Value="{Binding ActualHeight, ElementName=mnuMainMenu}"/>
                     </Style>
                 </Menu.Resources>
-                <MenuItem Header="_Undo" Command="{Binding UndoCommand}" TabIndex="0"/>
-                <MenuItem Header="_Options..." Command="{Binding OptionsCommand}"  TabIndex="1"/>
-                <MenuItem Header="_Bookmarks..." Command="{Binding BookmarkOpenCommand}" TabIndex="2"/>
-                <MenuItem Header="_About" TabIndex="3">
+                <MenuItem Header="_Undo" Command="{Binding UndoCommand}" TabIndex="0" VerticalContentAlignment="Center" VerticalAlignment="Center" Margin="0,0,3,0"/>
+                <MenuItem Header="_Options..." Command="{Binding OptionsCommand}"  TabIndex="1" VerticalContentAlignment="Center" VerticalAlignment="Center" Margin="0,0,3,0"/>
+                <MenuItem Header="_Bookmarks..." Command="{Binding BookmarkOpenCommand}" TabIndex="2" Margin="0,0,3,0" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
+                <MenuItem Header="_About" TabIndex="3" Height="22" Margin="0,0,3,0" VerticalContentAlignment="Center" VerticalAlignment="Center">
                     <MenuItem Command="{Binding HelpCommand}" Header="_Help"/>
                     <MenuItem Command="{Binding AboutCommand}" Header="_About dnGrep..."/>
                 </MenuItem>
@@ -49,14 +48,14 @@
         <StatusBar ClipToBounds="False" DockPanel.Dock="Bottom">
             <StatusBarItem>
                 <StackPanel Orientation="Horizontal">
-                    <ProgressBar Height="18" IsIndeterminate="{Binding IsOperationInProgress}" Width="150" />
+                    <ProgressBar Height="18" IsIndeterminate="{Binding IsOperationInProgress}" Width="150" VerticalContentAlignment="Center" VerticalAlignment="Center" Margin="3,0" />
                     <TextBlock Text="{Binding StatusMessage}" Margin="3,0" />
                 </StackPanel>
             </StatusBarItem>
             <StatusBarItem HorizontalAlignment="Right">
                 <StackPanel Orientation="Horizontal" Visibility="{Binding IsSaveInProgress, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <ProgressBar Height="18" IsIndeterminate="true" Width="150" />
-                    <TextBlock Text="Saving results to file..." Margin="3,0,12,0"/>
+                    <ProgressBar Height="18" IsIndeterminate="true" Width="150" VerticalAlignment="Center" VerticalContentAlignment="Center" Margin="3,0" />
+                    <TextBlock Text="Saving results to file..." Margin="3,0,12,0" VerticalAlignment="Center"/>
                 </StackPanel>
             </StatusBarItem>
         </StatusBar>
@@ -74,16 +73,15 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Row="0" Grid.Column="0" Margin="3" Text="Folder:" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <ComboBox x:Name="SearchText" Grid.Row="0" Grid.Column="1" Margin="3" TabIndex="10"
-                              Text="{Binding FileOrFolderPath}" ItemsSource="{Binding FastPathBookmarks}" IsEditable="True" />
-                    <Button Grid.Row="0" Grid.Column="2" Command="{Binding BrowseCommand}" Width="42" Margin="3" 
-                            ToolTip="Browse for folder or files" TabIndex="11" Content="..."/>
-
-                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="{Binding IsFiltersExpanded}" TabIndex="14">
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Folder:" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="3,8"/>
+                    <ComboBox x:Name="SearchText" Grid.Row="0" Grid.Column="1" Margin="3,4" TabIndex="10"
+                              Text="{Binding FileOrFolderPath}" ItemsSource="{Binding FastPathBookmarks}" IsEditable="True" Height="24" />
+                    <Button Grid.Row="0" Grid.Column="2" Command="{Binding BrowseCommand}" Width="32" Margin="3,4" 
+                            ToolTip="Browse for folder or files" TabIndex="11" Content="..." Height="24"/>
+                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="{Binding IsFiltersExpanded}" TabIndex="14" Margin="0">
                         <Expander.Header>
                             <StackPanel Margin="0,6" Orientation="Horizontal">
-                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="File Options"/>
+                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="Search Options"/>
                                 <TextBlock Margin="12,0,0,0" Text="{Binding FileFiltersSummary}" Foreground="DimGray"
                                            MaxWidth="{Binding Path=ActualWidth, ElementName=SearchText}" TextTrimming="CharacterEllipsis"/>
                             </StackPanel>
@@ -91,15 +89,14 @@
                         <GroupBox>
                             <WrapPanel SizeChanged="WrapPanel_SizeChanged">
                                 <!-- left -->
-                                <StackPanel x:Name="LeftFileOptions">
-                                    <Button Content="Reset Options" Margin="3,3" Padding="10,4" HorizontalAlignment="Left" Command="{Binding ResetOptionsCommand}" TabIndex="20"/>
-                                    <RadioButton GroupName="SizeFilter" Margin="3" Name="rbFilterAllSizes" TabIndex="21" Content="All sizes"
-                                                 IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=No}"/>
+                                <StackPanel x:Name="LeftFileOptions" Margin="3,5,15,3">
+                                    <RadioButton GroupName="SizeFilter" Margin="3" Name="rbFilterAllSizes" TabIndex="20" Content="All sizes"
+                                                 IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=No}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     <StackPanel Orientation="Horizontal">
-                                        <RadioButton GroupName="SizeFilter" Margin="3" VerticalAlignment="Center" Name="rbFilterSpecificSize" TabIndex="22" Content="Size is"
-                                                     IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=Yes}"/>
-                                        <TextBox Width="47" Margin="3" Name="tbFileSizeFrom" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="23"
-                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                        <RadioButton GroupName="SizeFilter" Margin="3" VerticalAlignment="Center" Name="rbFilterSpecificSize" TabIndex="21" Content="Size is"
+                                                     IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=Yes}" VerticalContentAlignment="Center"/>
+                                        <TextBox Width="48" Margin="3" Name="tbFileSizeFrom" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="22"
+                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" Height="24">
                                             <TextBox.Text>
                                                 <Binding Path="SizeFrom" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -109,8 +106,8 @@
                                             </TextBox.Text>
                                         </TextBox>
                                         <TextBlock Margin="3" VerticalAlignment="Center">to</TextBlock>
-                                        <TextBox Width="47" Margin="3" Name="tbFileSizeTo" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="24"
-                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                        <TextBox Width="48" Margin="3" Name="tbFileSizeTo" IsEnabled="{Binding Path=IsSizeFilterSet}" TabIndex="23"
+                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center">
                                             <TextBox.Text>
                                                 <Binding Path="SizeTo" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -121,20 +118,19 @@
                                         </TextBox>
                                         <TextBlock Margin="3" VerticalAlignment="Center">KB</TextBlock>
                                     </StackPanel>
-                                    <CheckBox Margin="2" IsChecked="{Binding Path=IncludeSubfolder}" Name="cbIncludeSubfolders" TabIndex="25" Content="Include subfolders"/>
-                                    <CheckBox Margin="2" IsChecked="{Binding Path=IncludeHidden}" Name="cbIncludeHiddenFolders" TabIndex="26" Content="Include hidden folders"/>
-                                    <CheckBox Margin="2" IsChecked="{Binding Path=IncludeBinary}" Name="cbIncludeBinary" TabIndex="27" Content="Include binary files"/>
+                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeSubfolder}" Name="cbIncludeSubfolders" TabIndex="24" Content="Include subfolders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeHidden}" Name="cbIncludeHiddenFolders" TabIndex="25" Content="Include hidden folders" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <CheckBox Margin="3" IsChecked="{Binding Path=IncludeBinary}" Name="cbIncludeBinary" TabIndex="26" Content="Include binary files" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                 </StackPanel>
-
                                 <!-- middle -->
-                                <StackPanel x:Name="MiddleFileOptions" Orientation="Vertical" VerticalAlignment="Bottom" Margin="18,0,0,0">
-                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,3">
-                                        <RadioButton GroupName="DateFilter" Margin="3,0" Content="All dates" TabIndex="30"
-                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=None}"/>
-                                        <RadioButton GroupName="DateFilter" Margin="3,0" Content="Modified" TabIndex="31"
-                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Modified}"/>
-                                        <RadioButton GroupName="DateFilter" Margin="3,0" Content="Created" TabIndex="32"
-                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Created}"/>
+                                <StackPanel x:Name="MiddleFileOptions" Orientation="Vertical" VerticalAlignment="Top" Margin="3,5,15,3">
+                                    <StackPanel Orientation="Horizontal" Margin="-6,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <RadioButton GroupName="DateFilter" Margin="3" Content="All dates" TabIndex="30"
+                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=None}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <RadioButton GroupName="DateFilter" Margin="3" Content="Modified" TabIndex="31"
+                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Modified}" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
+                                        <RadioButton GroupName="DateFilter" Margin="3" Content="Created" TabIndex="32"
+                                                     IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Created}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </StackPanel>
                                     <Grid>
                                         <Grid.RowDefinitions>
@@ -145,34 +141,34 @@
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
-                                        <RadioButton GroupName="TimeRange" Grid.Row="0" Grid.Column="0" Margin="3,0" VerticalAlignment="Center" Content="From"
+                                        <RadioButton GroupName="TimeRange" Grid.Row="0" Grid.Column="0" Margin="3,6" VerticalAlignment="Center" Content="From"
                                                      IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Dates}"
-                                                     IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="33"/>
-                                        <DatePicker Grid.Row="0" Grid.Column="1" Margin="3,2" Width="110" TabIndex="34" ToolTip="from the start of the day"
+                                                     IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="33" VerticalContentAlignment="Center"/>
+                                        <DatePicker Grid.Row="0" Grid.Column="1" Margin="3,2" Width="112" TabIndex="34" ToolTip="from the start of the day"
                                                     CalendarStyle="{StaticResource CalendarStyle}"
                                                     DisplayDate="{x:Static sys:DateTime.Now}"
                                                     DisplayDateStart="{Binding MinStartDate}"
                                                     SelectedDate="{Binding StartDate}"
-                                                    IsEnabled="{Binding IsDatesRangeSet}"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="3,0" HorizontalAlignment="Right" VerticalAlignment="Center" Text="To"/>
-                                        <DatePicker Grid.Row="1" Grid.Column="1" Margin="3,2" Width="110" TabIndex="35" ToolTip="through the end of the day"
+                                                    IsEnabled="{Binding IsDatesRangeSet}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"/>
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="20,6,0,6" HorizontalAlignment="Left" VerticalAlignment="Center" Text="To"/>
+                                        <DatePicker Grid.Row="1" Grid.Column="1" Margin="3,2" Width="112" TabIndex="35" ToolTip="through the end of the day"
                                                     CalendarStyle="{StaticResource CalendarStyle}"
                                                     DisplayDateStart="{Binding MinEndDate}"
                                                     DisplayDate="{x:Static sys:DateTime.Now}"
                                                     SelectedDate="{Binding EndDate}"
-                                                    IsEnabled="{Binding IsDatesRangeSet}"/>
+                                                    IsEnabled="{Binding IsDatesRangeSet}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"/>
                                     </Grid>
-                                    <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
                                         <RadioButton GroupName="TimeRange" Margin="3" VerticalAlignment="Center" Content="Past"
                                                      IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Hours}"
-                                                     IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="36"/>
-                                        <TextBox Width="47" Margin="3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="37"
+                                                     IsEnabled="{Binding Path=IsDateFilterSet}" TabIndex="36" VerticalContentAlignment="Center"/>
+                                        <TextBox Width="45" Margin="9,3,3,3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="37"
                                                  GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting"
-                                                 Text="{Binding HoursFrom, UpdateSourceTrigger=PropertyChanged}"/>
+                                                 Text="{Binding HoursFrom, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" HorizontalAlignment="Center" Height="24"/>
 
-                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="to"/>
-                                        <TextBox Width="47" Margin="3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="38"
-                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="to" HorizontalAlignment="Center"/>
+                                        <TextBox Width="45" Margin="3" IsEnabled="{Binding IsHoursRangeSet}" TabIndex="38"
+                                                 GotFocus="TextBoxFocus" PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting" VerticalAlignment="Center" HorizontalAlignment="Center" Height="24">
                                             <TextBox.Text>
                                                 <Binding Path="HoursTo" UpdateSourceTrigger="PropertyChanged">
                                                     <Binding.ValidationRules>
@@ -181,106 +177,102 @@
                                                 </Binding>
                                             </TextBox.Text>
                                         </TextBox>
-                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="hours"/>
+                                        <TextBlock Margin="3" VerticalAlignment="Center" Text="hours" HorizontalAlignment="Center"/>
                                     </StackPanel>
                                 </StackPanel>
-
                                 <Border x:Name="SpacerFileOptions"/>
-
                                 <!-- right -->
-                                <Grid x:Name="RightFileOptions" Margin="18,6,0,0">
+                                <Grid x:Name="RightFileOptions" Margin="3,5,3,3">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <StackPanel  Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center" Margin="3,0">
+                                    <StackPanel  Grid.Row="0" Grid.Column="1" Margin="3,0" HorizontalAlignment="Right">
                                         <StackPanel Orientation="Horizontal">
                                             <RadioButton GroupName="FileSearchType" Margin="3" Name="rbFileRegex" TabIndex="40" Content="Regex"
                                                          IsChecked="{Binding Path=TypeOfFileSearch, Converter={StaticResource ebc}, ConverterParameter=Regex}" 
-                                                         ToolTip="e.g. file[0-9]{1,2}\\.txt" />
+                                                         ToolTip="e.g. file[0-9]{1,2}\\.txt" VerticalContentAlignment="Center" VerticalAlignment="Center" />
                                             <RadioButton GroupName="FileSearchType" Margin="3" Name="rbFileAsterisk" TabIndex="41" Content="Asterisk pattern"
                                                          IsChecked="{Binding Path=TypeOfFileSearch, Converter={StaticResource ebc}, ConverterParameter=Asterisk}" 
-                                                         ToolTip="e.g. file??.*"/>
+                                                         ToolTip="e.g. file??.*" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Top" Margin="3,8">
-                                        <TextBlock VerticalAlignment="Center" Margin="0,0,3,0" Text="Encoding:" />
-                                        <ComboBox Width="240" Name="cbEncoding" TabIndex="42" Margin="3,0"
+                                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="3">
+                                        <TextBlock VerticalAlignment="Center" Margin="3" Text="Encoding:" HorizontalAlignment="Left" />
+                                        <ComboBox Width="224" Name="cbEncoding" TabIndex="42" Margin="3"
                                               DisplayMemberPath="Key" SelectedValuePath="Value" ItemsSource="{Binding Path=Encodings}"
-                                              VerticalAlignment="Top" SelectedValue="{Binding Path=CodePage}" Initialized="cbEncoding_Initialized" />
+                                              VerticalAlignment="Center" SelectedValue="{Binding Path=CodePage}" Initialized="cbEncoding_Initialized" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24" />
                                     </StackPanel>
-                                    <UniformGrid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="8" HorizontalAlignment="Center" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
-                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word"/>
-                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="45" Content="_Multiline"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="46" Content="_Dot as newline"/>
+                                    <UniformGrid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="4,3,3,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </UniformGrid>
+                                    <Button Content="Reset Options" Margin="3" Command="{Binding ResetOptionsCommand}" TabIndex="46" Height="24" Grid.Row="3" Width="98" Grid.Column="1" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
                                 </Grid>
                             </WrapPanel>
                         </GroupBox>
                     </Expander>
-
                     <!-- must be *after* the Expander so they are higher in the z-order -->
-                    <TextBlock Grid.Row="0" Grid.Column="3" Text="Paths that match:" Foreground="Black" Margin="3"
-                                   TextWrapping="NoWrap" VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                    <ComboBox Grid.Row="0" Grid.Column="4" Name="tbFilePattern" TabIndex="12" Margin="3"
+                    <TextBlock Grid.Row="0" Grid.Column="3" Text="Paths to match:" Foreground="Black" Margin="3,8"
+                                   TextWrapping="NoWrap" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                    <ComboBox Grid.Row="0" Grid.Column="4" Name="tbFilePattern" TabIndex="12" Margin="3,4"
                                   Text="{Binding Path=FilePattern, UpdateSourceTrigger=PropertyChanged}" 
                                   ItemsSource="{Binding Path=FastFileMatchBookmarks}" 
                                   GotFocus="TextBoxFocus" IsEditable="True"
                                   my:DiginesisHelpProvider.HelpKeyword="SearchReplace" 
                                   my:DiginesisHelpProvider.HelpNavigator="Topic" 
-                                  my:DiginesisHelpProvider.ShowHelp="True" />
-
-                    <TextBlock Grid.Row="1" Grid.Column="3"  Text="Paths to ignore:" Margin="3"
+                                  my:DiginesisHelpProvider.ShowHelp="True" Height="24" />
+                    <TextBlock Grid.Row="1" Grid.Column="3"  Text="Paths to ignore:" Margin="3,8,3,0"
                                    Style="{StaticResource GrayedOutFilePattern}" 
-                                   TextWrapping="NoWrap" VerticalAlignment="Top" HorizontalAlignment="Right"/>
-                    <ComboBox Grid.Row="1" Grid.Column="4" Margin="3" Name="tbFilePatternIgnore" TabIndex="13"  VerticalAlignment="Top"
+                                   TextWrapping="NoWrap" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    <ComboBox Grid.Row="1" Grid.Column="4" Margin="3,4,3,0" Name="tbFilePatternIgnore" TabIndex="13"
                                   Text="{Binding Path=FilePatternIgnore, UpdateSourceTrigger=PropertyChanged}" 
                                   ItemsSource="{Binding Path=FastFileNotMatchBookmarks}" 
                                   GotFocus="TextBoxFocus" IsEditable="True" 
                                   my:DiginesisHelpProvider.HelpKeyword="SearchReplace" 
                                   my:DiginesisHelpProvider.HelpNavigator="Topic" 
-                                  my:DiginesisHelpProvider.ShowHelp="True"/>
+                                  my:DiginesisHelpProvider.ShowHelp="True" Height="24" VerticalAlignment="Top"/>
                 </Grid>
             </GroupBox>
-
             <GroupBox Header="Search" DockPanel.Dock="Top">
                 <DockPanel VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Height="Auto">
                     <DockPanel DockPanel.Dock="Top" Margin="0,0,0,5">
-                        <Button Content="Test" Command="{Binding TestCommand}" Margin="3,0" Padding="20,4"
-                                DockPanel.Dock="Right" TabIndex="55"/>
-                        <CheckBox ToolTip="{Binding IsBookmarkedTooltip}" Margin="0 0 5 0"
+                        <Button Content="Test Expression" Command="{Binding TestCommand}" Margin="3,0"
+                                DockPanel.Dock="Right" TabIndex="55" Height="24" Width="96"/>
+                        <CheckBox ToolTip="{Binding IsBookmarkedTooltip}" Margin="0,0,3,0"
                                   Template="{DynamicResource FavsMetroButtonTemplate}"
                                   IsChecked="{Binding IsBookmarked}" Command="{Binding BookmarkAddCommand}"
-                                  DockPanel.Dock="Right" TabIndex="54"/>
-                        <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
+                                  DockPanel.Dock="Right" TabIndex="54" Height="24" Width="24"/>
+                        <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Margin="75,0,0,0">
                             <RadioButton Content="_Regex" GroupName="SearchRegex" Margin="3"
                                          IsChecked="{Binding TypeOfSearch, ConverterParameter=Regex, Converter={StaticResource ebc}}" 
-                                         ToolTip="Regular expression search" TabIndex="50"/>
+                                         ToolTip="Regular expression search" TabIndex="50" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                             <RadioButton Content="_XPath" GroupName="SearchXPath" Margin="3"
                                          IsChecked="{Binding TypeOfSearch, ConverterParameter=XPath, Converter={StaticResource ebc}}" 
-                                         ToolTip="XPath search (XML documents only)" TabIndex="51"/>
+                                         ToolTip="XPath search (XML documents only)" TabIndex="51" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                             <RadioButton Content="_Text" GroupName="SearchText"  Margin="3" 
                                          IsChecked="{Binding TypeOfSearch, ConverterParameter=PlainText, Converter={StaticResource ebc}}" 
-                                         ToolTip="Plain text search" TabIndex="52"/>
+                                         ToolTip="Plain text search" TabIndex="52" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                             <RadioButton Content="_Phonetic" GroupName="SearchSoundex" Margin="3" 
                                          IsChecked="{Binding TypeOfSearch, ConverterParameter=Soundex, Converter={StaticResource ebc}}" 
-                                         ToolTip="Phonetic search" TabIndex="53"/>
+                                         ToolTip="Phonetic search" TabIndex="53" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                         </StackPanel>
                         <Label Content="{Binding ValidationMessage}" HorizontalAlignment="Center"/>
                     </DockPanel>
-                    <StackPanel DockPanel.Dock="Bottom" Margin="0,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <WrapPanel Orientation="Horizontal">
-                            <CheckBox Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="70" Content="C_ase sensitive"/>
-                            <CheckBox Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="71" Content="_Whole word"/>
-                            <CheckBox Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="72" Content="_Multiline"/>
-                            <CheckBox Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="73" Content="_Dot as newline"/>
+                    <StackPanel DockPanel.Dock="Bottom" Margin="0,5,0,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <WrapPanel Orientation="Horizontal" Margin="77,0,0,0">
+                            <CheckBox Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="70" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <CheckBox Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="71" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <CheckBox Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="72" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <CheckBox Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="73" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                         </WrapPanel>
                     </StackPanel>
                     <Grid>
@@ -293,16 +285,16 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition/>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="3,0" Text="Search for:"/>
-                        <ComboBox Grid.Row="0" Grid.Column="1" Margin="3,0" Text="{Binding SearchFor}" IsEditable="True" x:Name="tbSearchFor" ItemsSource="{Binding FastSearchBookmarks}" Style="{DynamicResource MultilineComboBoxStyle}"
+                        <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="3,4,3,5" Text="Search for:"/>
+                        <ComboBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,1" Text="{Binding SearchFor}" IsEditable="True" x:Name="tbSearchFor" ItemsSource="{Binding FastSearchBookmarks}" Style="{DynamicResource MultilineComboBoxStyle}"
                                   IsTextSearchCaseSensitive="True" FontFamily="Consolas" FontSize="12" TabIndex="60" my:DiginesisHelpProvider.HelpKeyword="Regular-Expressions" my:DiginesisHelpProvider.HelpNavigator="Topic"
                                   my:DiginesisHelpProvider.ShowHelp="True" Padding="5">
                             <ComboBox.ToolTip>
                                 <TextBlock><Run Text=". matches all characters"/><LineBreak/><Run Text="\w matches alpha-numerics"/><LineBreak/><Run Text="\d matches digits"/><LineBreak/><Run Text="\s matches space"/><LineBreak/><Run Text="* matches any number of characters"/><LineBreak/><Run Text="{}{1,3} matches 1 to 3 characters"/><LineBreak/><Run Text="For more Regex patterns hit F1"/></TextBlock>
                             </ComboBox.ToolTip>
                         </ComboBox>
-                        <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="3,0" Text="Replace with:"/>
-                        <ComboBox Grid.Row="2" Grid.Column="1" Margin="3,0" Text="{Binding ReplaceWith}" IsEditable="True" x:Name="tbReplaceWith" ItemsSource="{Binding FastReplaceBookmarks}" Style="{DynamicResource MultilineComboBoxStyle}"
+                        <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="3,5,3,4" Text="Replace with:"/>
+                        <ComboBox Grid.Row="2" Grid.Column="1" Margin="3,1,3,0" Text="{Binding ReplaceWith}" IsEditable="True" x:Name="tbReplaceWith" ItemsSource="{Binding FastReplaceBookmarks}" Style="{DynamicResource MultilineComboBoxStyle}"
                                   IsTextSearchCaseSensitive="True" FontFamily="Consolas" FontSize="12" TabIndex="61" Padding="5">
                             <ComboBox.ToolTip>
                                 <TextBlock><Run Text="$&amp; replaces entire regex"/><LineBreak/><Run Text="$1, $2, $3, etc... inserts the text matched between capturing parentheses into the replacement text"/><LineBreak/><Run Text="$$ inserts a single dollar sign into the replacement text"/></TextBlock>
@@ -318,15 +310,15 @@
                 <WrapPanel Grid.Column="0" HorizontalAlignment="Right" Orientation="Horizontal">
                     <CheckBox Content="Search _in results" IsChecked="{Binding SearchInResultsContent}" 
                               Visibility="{Binding CanSearchInResults, Converter={StaticResource BoolToVisibilityConverter}}" 
-                              VerticalAlignment="Center" Margin="3,0" TabIndex="80"/>
-                    <CheckBox Content="Pre_view file" IsChecked="{Binding PreviewFileContent}" VerticalAlignment="Center" Margin="3,0" TabIndex="81"/>
-                    <CheckBox Content="Stop after first match" IsChecked="{Binding StopAfterFirstMatch}" VerticalAlignment="Center" Margin="3,0" TabIndex="82"/>
-                    <Button Content="_Search" Width="67" Padding="0,4" Margin="3" IsDefault="True" Command="{Binding SearchCommand}" TabIndex="83"/>
-                    <Button Content="Replace" Width="64" Margin="3" Command="{Binding ReplaceCommand}" TabIndex="84"/>
-                    <Button Content=">>" Width="30" Margin="3" Click="btnOtherActions_Click" 
-                            ContextMenuService.Placement="Bottom" IsEnabled="{Binding CanSearchInResults}" TabIndex="85">
+                              VerticalAlignment="Center" Margin="3,0" TabIndex="80" VerticalContentAlignment="Center"/>
+                    <CheckBox Content="Pre_view file" IsChecked="{Binding PreviewFileContent}" VerticalAlignment="Center" Margin="3,0" TabIndex="81" VerticalContentAlignment="Center"/>
+                    <CheckBox Content="Stop after first match" IsChecked="{Binding StopAfterFirstMatch}" VerticalAlignment="Center" Margin="3,0" TabIndex="82" VerticalContentAlignment="Center"/>
+                    <Button Content="_Search" Width="64" Margin="3" IsDefault="True" Command="{Binding SearchCommand}" TabIndex="83" Height="24"/>
+                    <Button Content="Replace" Width="64" Margin="3" Command="{Binding ReplaceCommand}" TabIndex="84" Height="24"/>
+                    <Button Content=">>" Width="32" Margin="3" Click="btnOtherActions_Click" 
+                            ContextMenuService.Placement="Bottom" IsEnabled="{Binding CanSearchInResults}" TabIndex="85" Height="24">
                         <Button.ContextMenu>
-                            <ContextMenu x:Name="advanceContextMenu">
+                            <ContextMenu x:Name="advanceContextMenu">f
                                 <MenuItem Header="Copy files..." Command="{Binding CopyFilesCommand}"/>
                                 <MenuItem Header="Move files..." Command="{Binding MoveFilesCommand}"/>
                                 <MenuItem Header="Delete files..." Command="{Binding DeleteFilesCommand}"/>
@@ -337,7 +329,7 @@
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>
-                    <Button Content="_Cancel" Width="64" Margin="3,3,8,3" Command="{Binding CancelCommand}" TabIndex="86"/>
+                    <Button Content="_Cancel" Width="64" Margin="3,3,8,3" Command="{Binding CancelCommand}" TabIndex="86" Height="24"/>
                 </WrapPanel>
             </Grid>
             <Controls:ResultsTree DataContext="{Binding SearchResults}" TabIndex="90"/>

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -7,12 +7,12 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         mc:Ignorable="d"
-        Title="{Binding WindowTitle}" MinWidth="791" MinHeight="470" WindowState="Normal" d:DesignWidth="785"
+        Title="{Binding WindowTitle}" MinWidth="485" MinHeight="485" WindowState="Normal"
         Icon="/dnGREP;component/nGREP.ico" 
         Closing="MainForm_Closing" Loaded="Window_Loaded" Activated="Window_Activated" StateChanged="Window_StateChanged"
         SnapsToDevicePixels="True" ResizeMode="CanResizeWithGrip" AllowDrop="False"
         my:DiginesisHelpProvider.HelpKeyword="Search-Window" my:DiginesisHelpProvider.HelpNavigator="Topic" my:DiginesisHelpProvider.ShowHelp="True" 
-        WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}" Width="Auto">
+        WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}" d:DesignWidth="795">
     <Window.Resources>
         <my:InverseBooleanConverter x:Key="InverseBooleanConverter" />
         <my:TotalValueConverter x:Key="TotalValueConverter" />
@@ -78,7 +78,8 @@
                               Text="{Binding FileOrFolderPath}" ItemsSource="{Binding FastPathBookmarks}" IsEditable="True" Height="24" />
                     <Button Grid.Row="0" Grid.Column="2" Command="{Binding BrowseCommand}" Width="32" Margin="3,4" 
                             ToolTip="Browse for folder or files" TabIndex="11" Content="..." Height="24"/>
-                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="{Binding IsFiltersExpanded}" TabIndex="14" Margin="0">
+                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="True" TabIndex="14" Margin="0">
+                        <!--{Binding IsFiltersExpanded}-->
                         <Expander.Header>
                             <StackPanel Margin="0,6" Orientation="Horizontal">
                                 <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="Search Options"/>

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -25,7 +25,7 @@
     </Window.Background>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding CloseCommand}"/>
-        <KeyBinding Key="e" Command="{Binding ToggleFileOptionsCommand}" Modifiers="Alt" />
+        <KeyBinding Key="e" Modifiers="Alt" Command="{Binding ToggleFileOptionsCommand}" />
     </Window.InputBindings>
     <DockPanel ManipulationBoundaryFeedback="ManipulationBoundaryFeedbackHandler">
         <DockPanel DockPanel.Dock="Top" Margin="5,5,5,-2">
@@ -78,11 +78,10 @@
                               Text="{Binding FileOrFolderPath}" ItemsSource="{Binding FastPathBookmarks}" IsEditable="True" Height="24" />
                     <Button Grid.Row="0" Grid.Column="2" Command="{Binding BrowseCommand}" Width="32" Margin="3,4" 
                             ToolTip="Browse for folder or files" TabIndex="11" Content="..." Height="24"/>
-                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="True" TabIndex="14" Margin="0">
-                        <!--{Binding IsFiltersExpanded}-->
+                    <Expander Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="5" IsExpanded="{Binding IsFiltersExpanded}" TabIndex="14" Margin="0">
                         <Expander.Header>
                             <StackPanel Margin="0,6" Orientation="Horizontal">
-                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="More ..."/>
+                                <TextBlock x:Name="fileOptions" TextWrapping="NoWrap" Text="More..."/>
                                 <TextBlock Margin="12,0,0,0" Text="{Binding FileFiltersSummary}" Foreground="DimGray"
                                            MaxWidth="{Binding Path=ActualWidth, ElementName=SearchText}" TextTrimming="CharacterEllipsis"/>
                             </StackPanel>
@@ -213,8 +212,8 @@
                                     <UniformGrid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="4,3,3,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
                                         <CheckBox Grid.Row="0" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                         <CheckBox Grid.Row="1" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot as newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </UniformGrid>
                                     <Button Content="Reset Options" Margin="3,0,3,3" Command="{Binding ResetOptionsCommand}" TabIndex="46" Height="24" Grid.Row="3" Width="98" Grid.Column="1" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
                                 </Grid>
@@ -272,8 +271,8 @@
                         <WrapPanel Orientation="Horizontal" Margin="77,0,0,0">
                             <CheckBox Margin="3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="70" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                             <CheckBox Margin="3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="71" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                            <CheckBox Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="72" Content="_Multiline (slower)" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                            <CheckBox Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="73" Content="_Dot matches newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <CheckBox Margin="3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="72" Content="_Multiline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                            <CheckBox Margin="3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="73" Content="_Dot as newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                         </WrapPanel>
                     </StackPanel>
                     <Grid>

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -80,6 +80,15 @@ namespace dnGREP.WPF
             inputData.ParentWindow = this;
             DataObject.AddPastingHandler(tbSearchFor, new DataObjectPastingEventHandler(onPaste));
             DataObject.AddPastingHandler(tbReplaceWith, new DataObjectPastingEventHandler(onPaste));
+
+            var textBox = (tbSearchFor.Template.FindName("PART_EditableTextBox", tbSearchFor) as TextBox);
+            if (textBox != null && !tbSearchFor.IsDropDownOpen)
+            {
+                Application.Current.Dispatcher.BeginInvoke(new Action(() => {
+                    textBox.SelectAll();
+                    textBox.Focus();
+                }));
+            }
         }
 
         /// <summary>

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -234,7 +234,7 @@ namespace dnGREP.WPF
                 fileOptions.Inlines.Clear();
                 fileOptions.Inlines.Add(new Run("Mor"));
                 fileOptions.Inlines.Add(new Underline(new Run("e")));
-                fileOptions.Inlines.Add(new Run(" ..."));
+                fileOptions.Inlines.Add(new Run("..."));
             }
         }
 
@@ -242,7 +242,7 @@ namespace dnGREP.WPF
         {
             if (Keyboard.IsKeyUp(Key.LeftAlt) && Keyboard.IsKeyUp(Key.RightAlt))
             {
-                fileOptions.Text = "More ...";
+                fileOptions.Text = "More...";
             }
         }
     }

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -232,8 +232,9 @@ namespace dnGREP.WPF
             if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt))
             {
                 fileOptions.Inlines.Clear();
-                fileOptions.Inlines.Add(new Underline(new Run("S")));
-                fileOptions.Inlines.Add(new Run("earch Options"));
+                fileOptions.Inlines.Add(new Run("Mor"));
+                fileOptions.Inlines.Add(new Underline(new Run("e")));
+                fileOptions.Inlines.Add(new Run(" ..."));
             }
         }
 
@@ -241,7 +242,7 @@ namespace dnGREP.WPF
         {
             if (Keyboard.IsKeyUp(Key.LeftAlt) && Keyboard.IsKeyUp(Key.RightAlt))
             {
-                fileOptions.Text = "Search Options";
+                fileOptions.Text = "More ...";
             }
         }
     }

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -232,8 +232,8 @@ namespace dnGREP.WPF
             if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt))
             {
                 fileOptions.Inlines.Clear();
-                fileOptions.Inlines.Add(new Underline(new Run("F")));
-                fileOptions.Inlines.Add(new Run("ile Options"));
+                fileOptions.Inlines.Add(new Underline(new Run("S")));
+                fileOptions.Inlines.Add(new Run("earch Options"));
             }
         }
 
@@ -241,7 +241,7 @@ namespace dnGREP.WPF
         {
             if (Keyboard.IsKeyUp(Key.LeftAlt) && Keyboard.IsKeyUp(Key.RightAlt))
             {
-                fileOptions.Text = "File Options";
+                fileOptions.Text = "Search Options";
             }
         }
     }

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -58,7 +58,7 @@
                                         <ColumnDefinition Width="40"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBox Grid.Column="0" Text="{Binding Path=CustomEditorPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,1" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
-                                    <Button Grid.Column="1" Margin="7,2,1,1" Name="btnBrowse" Command="{Binding Path=BrowseCommand}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" Width="32">...</Button>
+                                    <Button Grid.Column="1" Margin="7,2,1,1" Name="btnBrowse" Command="{Binding Path=BrowseCommand}" Height="24" Width="32">...</Button>
                                     <DockPanel Grid.Row="1" Grid.Column="0">
                                         <Label VerticalAlignment="Center" VerticalContentAlignment="Center">Arguments</Label>
                                         <TextBox Text="{Binding Path=CustomEditorArgs, UpdateSourceTrigger=PropertyChanged}" Height="24" VerticalAlignment="Center" Margin="0,1" VerticalContentAlignment="Center"/>

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -57,11 +57,11 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="40"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox Grid.Column="0" Text="{Binding Path=CustomEditorPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,1" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"></TextBox>
+                                    <TextBox Grid.Column="0" Text="{Binding Path=CustomEditorPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,1" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
                                     <Button Grid.Column="1" Margin="7,2,1,1" Name="btnBrowse" Command="{Binding Path=BrowseCommand}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" Width="32">...</Button>
                                     <DockPanel Grid.Row="1" Grid.Column="0">
                                         <Label VerticalAlignment="Center" VerticalContentAlignment="Center">Arguments</Label>
-                                        <TextBox Text="{Binding Path=CustomEditorArgs, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" VerticalAlignment="Center" Margin="0,1" VerticalContentAlignment="Center"></TextBox>
+                                        <TextBox Text="{Binding Path=CustomEditorArgs, UpdateSourceTrigger=PropertyChanged}" Height="24" VerticalAlignment="Center" Margin="0,1" VerticalContentAlignment="Center"/>
                                     </DockPanel>
                                     <TextBlock Grid.Row="2" Grid.Column="0" TextWrapping="Wrap" VerticalAlignment="Center" Margin="70,0,0,0" Text="Use %file and %line keywords for file location and line number and %pattern for search pattern"/>
                                 </Grid>

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -18,11 +18,11 @@
             <RowDefinition />
         </Grid.RowDefinitions>
         <TabControl Name="tbMainPanel" Grid.Row="0" TabStripPlacement="Left" Grid.IsSharedSizeScope="True">
-            <TabItem Name="tbGeneralTab">
+            <TabItem Name="tbGeneralTab" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Center">
                 <TabItem.Header>
                     <WrapPanel Orientation="Vertical">
-                        <Image Source="..\Images\preferences-system.png" Width="32" Height="32"/>
-                        <TextBlock>General</TextBlock>
+                        <Image Source="..\Images\preferences-system.png" Width="32" Height="32" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center">General</TextBlock>
                     </WrapPanel>
                 </TabItem.Header>
                 <Grid>
@@ -33,16 +33,16 @@
                         <GroupBox Header="Startup options" Name="grShell" ToolTip="{Binding Path=PanelTooltip}">
                             <WrapPanel Orientation="Vertical">
                                 <CheckBox Margin="3" Name="cbRegisterShell" IsChecked="{Binding Path=EnableWindowsIntegration}" ToolTip="{Binding Path=WindowsIntegrationTooltip}"
-                                      IsEnabled="{Binding Path=IsAdministrator}">Enable Windows Explorer integration</CheckBox>
+                                      IsEnabled="{Binding Path=IsAdministrator}" VerticalContentAlignment="Center" VerticalAlignment="Center">Enable Windows Explorer integration</CheckBox>
                                 <CheckBox Margin="3" Name="cbRegisterStartup" IsChecked="{Binding Path=EnableStartupAcceleration}" ToolTip="{Binding Path=StartupAccelerationTooltip}"
-                                      IsEnabled="{Binding Path=IsAdministrator}">Enable startup accelerator</CheckBox>
+                                      IsEnabled="{Binding Path=IsAdministrator}" VerticalContentAlignment="Center" VerticalAlignment="Center">Enable startup accelerator</CheckBox>
                             </WrapPanel>
                         </GroupBox>
                         <GroupBox Header="Checking for updates">
                             <WrapPanel>
-                                <CheckBox Margin="3" VerticalAlignment="Center" Name="cbCheckForUpdates" IsChecked="{Binding Path=EnableCheckForUpdates}">Enable automatic checking every</CheckBox>
-                                <TextBox Width="30" Name="tbUpdateInterval" IsEnabled="{Binding ElementName=cbCheckForUpdates, Path=IsChecked}" Text="{Binding Path=CheckForUpdatesInterval, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-                                <Label Margin="3" VerticalAlignment="Center">days</Label>
+                                <CheckBox Margin="3" VerticalAlignment="Center" Name="cbCheckForUpdates" IsChecked="{Binding Path=EnableCheckForUpdates}" VerticalContentAlignment="Center">Enable automatic checking every</CheckBox>
+                                <TextBox Width="31" Name="tbUpdateInterval" IsEnabled="{Binding ElementName=cbCheckForUpdates, Path=IsChecked}" Text="{Binding Path=CheckForUpdatesInterval, UpdateSourceTrigger=PropertyChanged}" Height="24" Margin="3,0,0,0" VerticalContentAlignment="Center" VerticalAlignment="Center"></TextBox>
+                                <Label Margin="0,3,3,3" VerticalAlignment="Center" VerticalContentAlignment="Center">days</Label>
                             </WrapPanel>
                         </GroupBox>
                         <GroupBox Header="Custom editor">
@@ -57,25 +57,25 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition Width="40"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox Grid.Column="0" Text="{Binding Path=CustomEditorPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,3" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}"></TextBox>
-                                    <Button Grid.Column="1" Margin="5,0,0,0" Name="btnBrowse" Command="{Binding Path=BrowseCommand}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}">...</Button>
+                                    <TextBox Grid.Column="0" Text="{Binding Path=CustomEditorPath, UpdateSourceTrigger=PropertyChanged}" Margin="0,2,0,1" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" VerticalAlignment="Center" VerticalContentAlignment="Center"></TextBox>
+                                    <Button Grid.Column="1" Margin="7,2,1,1" Name="btnBrowse" Command="{Binding Path=BrowseCommand}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" Width="32">...</Button>
                                     <DockPanel Grid.Row="1" Grid.Column="0">
-                                        <Label>Arguments</Label>
-                                        <TextBox Text="{Binding Path=CustomEditorArgs, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}"></TextBox>
+                                        <Label VerticalAlignment="Center" VerticalContentAlignment="Center">Arguments</Label>
+                                        <TextBox Text="{Binding Path=CustomEditorArgs, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=rbSpecificEditor, Path=IsChecked}" Height="24" VerticalAlignment="Center" Margin="0,1" VerticalContentAlignment="Center"></TextBox>
                                     </DockPanel>
-                                    <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap">(use %file and %line keywords for file location and line number and %pattern for search pattern)</TextBlock>
+                                    <TextBlock Grid.Row="2" Grid.Column="0" TextWrapping="Wrap" VerticalAlignment="Center" Margin="70,0,0,0" Text="Use %file and %line keywords for file location and line number and %pattern for search pattern"/>
                                 </Grid>
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Name="tbUserInterfaceTab">
+            <TabItem Name="tbUserInterfaceTab" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Center">
                 <TabItem.Header>
                     <WrapPanel Orientation="Vertical">
-                        <Image Source="..\Images\applications-graphics.png" Width="32" Height="32"/>
-                        <TextBlock HorizontalAlignment="Center">User</TextBlock>
-                        <TextBlock HorizontalAlignment="Center">Interface</TextBlock>
+                        <Image Source="..\Images\applications-graphics.png" Width="32" Height="32" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">User</TextBlock>
+                        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">Interface</TextBlock>
                     </WrapPanel>
                 </TabItem.Header>
                 <Grid>
@@ -84,60 +84,60 @@
                     </Grid.RowDefinitions>
                     <StackPanel HorizontalAlignment="Stretch">
                         <StackPanel Orientation="Horizontal" Margin="0,3">
-                            <TextBlock Text="Show search options:" Margin="6,0"/>
+                            <TextBlock Text="Show search options:" Margin="6,0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             <RadioButton Content="on main panel" GroupName="searchLocation" Margin="3,0" 
-                                         IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=MainPanel}"/>
+                                         IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=MainPanel}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                             <RadioButton Content="in options expander" GroupName="searchLocation" Margin="3,0" 
-                                         IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=OptionsExpander}"/>
+                                         IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=OptionsExpander}" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                         </StackPanel>
-                        <CheckBox Name="cbShowPath" Margin="3" IsChecked="{Binding Path=ShowFilePathInResults}">Show file path in results panel</CheckBox>
+                        <CheckBox Name="cbShowPath" Margin="3" IsChecked="{Binding Path=ShowFilePathInResults}" VerticalAlignment="Center">Show file path in results panel</CheckBox>
                         <StackPanel Orientation="Horizontal">
-                            <CheckBox Name="cbShowContext" Margin="3" VerticalAlignment="Center" IsChecked="{Binding Path=ShowLinesInContext}">Show result lines in context</CheckBox>
-                            <TextBox Width="40" Text="{Binding Path=ContextLinesBefore, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=cbShowContext, Path=IsChecked}"></TextBox>
+                            <CheckBox Name="cbShowContext" Margin="3" VerticalAlignment="Center" IsChecked="{Binding Path=ShowLinesInContext}" HorizontalAlignment="Center" VerticalContentAlignment="Center">Show result lines in context</CheckBox>
+                            <TextBox Width="32" Text="{Binding Path=ContextLinesBefore, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=cbShowContext, Path=IsChecked}" Height="24" Margin="3,0,0,0" VerticalAlignment="Center" VerticalContentAlignment="Center"></TextBox>
                             <Label VerticalAlignment="Center">before</Label>
-                            <TextBox Width="40" Text="{Binding Path=ContextLinesAfter, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=cbShowContext, Path=IsChecked}"></TextBox>
+                            <TextBox Width="32" Text="{Binding Path=ContextLinesAfter, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding ElementName=cbShowContext, Path=IsChecked}" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center"></TextBox>
                             <Label VerticalAlignment="Center">after</Label>
                         </StackPanel>
-                        <CheckBox Margin="3" Name="cbSearchFileNameOnly" IsChecked="{Binding Path=AllowSearchWithEmptyPattern}">
+                        <CheckBox Margin="3" Name="cbSearchFileNameOnly" IsChecked="{Binding Path=AllowSearchWithEmptyPattern}" VerticalContentAlignment="Center" VerticalAlignment="Center">
                             <CheckBox.Content>
-                                <TextBlock TextWrapping="Wrap">Allow searching for file name pattern only when "search for" is empty</TextBlock>
+                                <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center">Allow searching for file name pattern only when "search for" is empty</TextBlock>
                             </CheckBox.Content>
                         </CheckBox>
-                        <CheckBox Margin="3" Name="cbExpandResult" IsChecked="{Binding Path=AutoExpandSearchTree}">
+                        <CheckBox Margin="3" Name="cbExpandResult" IsChecked="{Binding Path=AutoExpandSearchTree}" VerticalContentAlignment="Center" VerticalAlignment="Center">
                             <CheckBox.Content>
-                                <TextBlock TextWrapping="Wrap">Show results tree expanded</TextBlock>
+                                <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center">Show results tree expanded</TextBlock>
                             </CheckBox.Content>
                         </CheckBox>
-                        <CheckBox Margin="3" Name="cbShowMatchVerbose" IsChecked="{Binding Path=ShowVerboseMatchCount}">
+                        <CheckBox Margin="3" Name="cbShowMatchVerbose" IsChecked="{Binding Path=ShowVerboseMatchCount}" VerticalContentAlignment="Center" VerticalAlignment="Center">
                             <CheckBox.Content>
-                                <TextBlock TextWrapping="Wrap">Show verbose match count</TextBlock>
+                                <TextBlock TextWrapping="Wrap" HorizontalAlignment="Center" VerticalAlignment="Center">Show verbose match count</TextBlock>
                             </CheckBox.Content>
                         </CheckBox>
                         <StackPanel Orientation="Horizontal">
-                            <TextBox Text="{Binding MaxPathBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="50" Margin="3,0" TextAlignment="Right"
-                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" />
+                            <TextBox Text="{Binding MaxPathBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="3,0" TextAlignment="Right"
+                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center" />
                             <TextBlock Text="items shown in path history list" Margin="3"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <TextBox Text="{Binding MaxSearchBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="50" Margin="3,0" TextAlignment="Right"
-                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" />
+                            <TextBox Text="{Binding MaxSearchBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="3,0" TextAlignment="Right"
+                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center" />
                             <TextBlock Text="items shown in search and replace history lists" Margin="3"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <TextBox Text="{Binding MaxExtensionBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="50" Margin="3,0" TextAlignment="Right"
-                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" />
+                            <TextBox Text="{Binding MaxExtensionBookmarks, UpdateSourceTrigger=PropertyChanged}" Width="48" Margin="3,0" TextAlignment="Right"
+                                 PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBox_Pasting" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center" />
                             <TextBlock Text="items shown in file filter history lists" Margin="3"/>
                         </StackPanel>
-                        <Button Height="23" Name="btnClearPreviousSearches" Width="104" HorizontalAlignment="Left" Margin="6,3" Command="{Binding Path=ClearSearchesCommand}">Clear old searches</Button>
+                        <Button Height="24" Name="btnClearPreviousSearches" Width="112" HorizontalAlignment="Left" Margin="3" Command="{Binding Path=ClearSearchesCommand}" VerticalAlignment="Center">Clear old searches</Button>
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Name="tbSearchOptionsTab">
+            <TabItem Name="tbSearchOptionsTab" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" VerticalAlignment="Center">
                 <TabItem.Header>
                     <WrapPanel Orientation="Vertical">
-                        <Image Source="..\Images\system-search.png" Width="32" Height="32"/>
-                        <TextBlock HorizontalAlignment="Center">Search</TextBlock>
-                        <TextBlock HorizontalAlignment="Center">Params</TextBlock>
+                        <Image Source="..\Images\system-search.png" Width="32" Height="32" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">Search</TextBlock>
+                        <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">Params</TextBlock>
                     </WrapPanel>
                 </TabItem.Header>
                 <Grid>
@@ -157,8 +157,8 @@
                                     </DataTemplate>
                                 </WrapPanel.Resources>
                                 <Label>Match threshold (from 0 to 1.0)</Label>
-                                <TextBox Name="tbFuzzyMatchThreshold" Width="50" Text="{Binding Path=MatchThreshold, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
-                                     Validation.ErrorTemplate="{x:Null}"></TextBox>
+                                <TextBox Name="tbFuzzyMatchThreshold" Width="48" Text="{Binding Path=MatchThreshold, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
+                                     Validation.ErrorTemplate="{x:Null}" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                 <Label>0 - match everything; 1.0 - exact match</Label>
                                 <ContentPresenter Content="{Binding ElementName=tbFuzzyMatchThreshold, Path=(Validation.Errors).CurrentItem}"/>
                             </WrapPanel>
@@ -168,8 +168,8 @@
             </TabItem>
         </TabControl>
         <WrapPanel Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Bottom">
-            <Button Width="70" Margin="0,5,5,5" Command="{Binding Path=SaveCommand}" IsDefault="True">Save</Button>
-            <Button Width="70" Margin="0,5,5,5" Command="{Binding Path=CloseCommand}">Cancel</Button>
+            <Button Width="64" Margin="0,5,10,5" Command="{Binding Path=SaveCommand}" IsDefault="True" Height="24" VerticalAlignment="Center">Save</Button>
+            <Button Width="64" Margin="0,5,15,5" Command="{Binding Path=CloseCommand}" Height="24" VerticalAlignment="Center">Cancel</Button>
         </WrapPanel>
     </Grid>
 </Window>

--- a/dnGREP.WPF/Views/PreviewView.xaml
+++ b/dnGREP.WPF/Views/PreviewView.xaml
@@ -9,14 +9,14 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="100"/>
             </Grid.ColumnDefinitions>
-            <Label Grid.Column="0">This file is either binary or too large to preview.</Label>
-            <Button Grid.Column="1" Click="Button_Click">Preview anyway</Button>
+            <Label Grid.Column="0" VerticalAlignment="Center" VerticalContentAlignment="Center">This file is either binary or too large to preview.</Label>
+            <Button Click="Button_Click" Height="24" Width="112" Grid.ColumnSpan="2" Margin="473,1,0,1" VerticalAlignment="Center">Preview anyway</Button>
         </Grid>
-        <StatusBar DockPanel.Dock="Bottom" ClipToBounds="False" Grid.Row="4" Name="statusBar">
-            <TextBlock>Zoom:</TextBlock>
-            <Slider Name="zoomSlider" ToolTip="Changes text editor zoom" Value="12" Minimum="9" Maximum="30" Width="200" HorizontalAlignment="Right"/>
-            <CheckBox Name="cbWrapText">Wrap text</CheckBox>
-            <ComboBox Name="cbHighlighter" ItemsSource="{Binding Path=Highlighters}" SelectedValue="{Binding Path=CurrentSyntax}"></ComboBox>
+        <StatusBar DockPanel.Dock="Bottom" ClipToBounds="False" Grid.Row="4" Name="statusBar" VerticalContentAlignment="Center" VerticalAlignment="Center">
+            <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0,0,3,0">Zoom:</TextBlock>
+            <Slider Name="zoomSlider" ToolTip="Changes text editor zoom" Value="12" Minimum="9" Maximum="30" Width="200" HorizontalAlignment="Right" VerticalContentAlignment="Center" VerticalAlignment="Center" Margin="0,0,3,0"/>
+            <CheckBox Name="cbWrapText" VerticalContentAlignment="Center" VerticalAlignment="Center" Margin="0,0,3,0">Wrap text</CheckBox>
+            <ComboBox Name="cbHighlighter" ItemsSource="{Binding Path=Highlighters}" SelectedValue="{Binding Path=CurrentSyntax}" VerticalContentAlignment="Center" Margin="0,0,3,0"></ComboBox>
         </StatusBar>
         <ae:TextEditor Name="textEditor" FontFamily="Consolas" FontSize="{Binding ElementName=zoomSlider,Path=Value}" ShowLineNumbers="True" 
                        IsReadOnly="True" WordWrap="{Binding ElementName=cbWrapText,Path=IsChecked}" />

--- a/dnGREP.WPF/Views/Test.xaml
+++ b/dnGREP.WPF/Views/Test.xaml
@@ -29,8 +29,8 @@
                         </ContextMenu>
                     </TextBox.ContextMenu>
                 </TextBox>
-                <Button Grid.Column="1" Name="button1" HorizontalContentAlignment="Center" VerticalAlignment="Top" Width="auto" Click="button1_Click"
-                        FontFamily="Marlett" FontSize="15" Content="6" PreviewMouseLeftButtonDown="DragSource_PreviewMouseLeftButtonDown" PreviewMouseMove="DragSource_PreviewMouseMove"></Button>
+                <Button Grid.Column="1" Name="button1" HorizontalContentAlignment="Center" VerticalAlignment="Top" Width="32" Click="button1_Click"
+                        FontFamily="Marlett" FontSize="15" Content="6" PreviewMouseLeftButtonDown="DragSource_PreviewMouseLeftButtonDown" PreviewMouseMove="DragSource_PreviewMouseMove" Height="24"></Button>
             </Grid>
         </Border>
     </Grid>

--- a/dnGREP.WPF/Views/TestPatternView.xaml
+++ b/dnGREP.WPF/Views/TestPatternView.xaml
@@ -36,22 +36,22 @@
                         <RowDefinition Height="23"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="*"/>
-                        <RowDefinition />
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal">
-                        <RadioButton GroupName="SearchRegex" Name="rbRegex" Margin="3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=Regex}">Regex</RadioButton>
-                        <RadioButton GroupName="SearchXPath" Name="rbXPath" Margin="3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=XPath}">XPath</RadioButton>
-                        <RadioButton GroupName="SearchText" Name="rbText" Margin="3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=PlainText}">Text</RadioButton>
-                        <RadioButton GroupName="SearchSoundex" Name="rbSoundex" Margin="3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=Soundex}">Phonetic</RadioButton>
+                        <RadioButton GroupName="SearchRegex" Name="rbRegex" Margin="3,4,3,3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=Regex}" VerticalContentAlignment="Center" VerticalAlignment="Center">Regex</RadioButton>
+                        <RadioButton GroupName="SearchXPath" Name="rbXPath" Margin="3,4,3,3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=XPath}" VerticalContentAlignment="Center" VerticalAlignment="Center">XPath</RadioButton>
+                        <RadioButton GroupName="SearchText" Name="rbText" Margin="3,4,3,3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=PlainText}" VerticalContentAlignment="Center" VerticalAlignment="Center">Text</RadioButton>
+                        <RadioButton GroupName="SearchSoundex" Name="rbSoundex" Margin="3,4,3,3" IsChecked="{Binding Path=TypeOfSearch, Converter={StaticResource ebc}, ConverterParameter=Soundex}" VerticalContentAlignment="Center" VerticalAlignment="Center">Phonetic</RadioButton>
                     </StackPanel>
                     <GroupBox Header="Search for:" Grid.Row="1" 
-                              Grid.ColumnSpan="2" BorderThickness="0">
+                              Grid.ColumnSpan="2" BorderThickness="0" VerticalContentAlignment="Center" VerticalAlignment="Center">
                         <TextBox Name="tbSearchFor" Margin="-5,3,-5,0" Text="{Binding Path=SearchFor, UpdateSourceTrigger=PropertyChanged}" 
                                  VerticalScrollBarVisibility="Auto" 
-                                 Style="{StaticResource ExpandedTextbox}">
+                                 Style="{StaticResource ExpandedTextbox}" VerticalContentAlignment="Center" VerticalAlignment="Center" Height="24">
                             <TextBox.ToolTip>
                                 <TextBlock>
                                         <Run>. matches all characters</Run>
@@ -72,11 +72,11 @@
                         </TextBox>
                     </GroupBox>
                     <GroupBox Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" 
-                              Header="Replace with:" BorderThickness="0">
+                              Header="Replace with:" BorderThickness="0" VerticalContentAlignment="Center" VerticalAlignment="Center">
                         <TextBox Margin="-5,3,-5,0" Name="tbReplaceWith" 
                                  Text="{Binding Path=ReplaceWith, UpdateSourceTrigger=PropertyChanged}"  
                                  VerticalScrollBarVisibility="Auto" 
-                                 Style="{StaticResource ExpandedTextbox}">
+                                 Style="{StaticResource ExpandedTextbox}" VerticalContentAlignment="Center" VerticalAlignment="Center" Height="24">
                             <TextBox.ToolTip>
                                 <TextBlock>
                                             <Run><![CDATA[$& replaces entire regex]]></Run>
@@ -88,21 +88,15 @@
                             </TextBox.ToolTip>
                         </TextBox>
                     </GroupBox>
-                    <Expander Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2"
-                              Name="expOptions">
-                        <Expander.Header>
-                            <WrapPanel>
-                                <TextBlock>Options</TextBlock>
-                                <TextBlock Margin="15,0,0,0" Text="{Binding Path=OptionsSummary}"/>
-                            </WrapPanel>
-                        </Expander.Header>
+                    <GroupBox Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2" 
+                             BorderThickness="0" VerticalContentAlignment="Center" VerticalAlignment="Center">
                         <StackPanel Orientation="Horizontal">
-                            <CheckBox Margin="3" Name="cbCaseSensitive" IsChecked="{Binding Path=CaseSensitive}" IsEnabled="{Binding Path=IsCaseSensitiveEnabled}">Case sensitive</CheckBox>
-                            <CheckBox Margin="3" Name="cbMultiline" IsChecked="{Binding Path=Multiline}" IsEnabled="{Binding Path=IsMultilineEnabled}">Multiline (slower)</CheckBox>
-                            <CheckBox Margin="3" Name="cbWholeWord" IsChecked="{Binding Path=WholeWord}" IsEnabled="{Binding Path=IsWholeWordEnabled}">Whole word</CheckBox>
-                            <CheckBox Margin="3" Name="cbSingleline" IsChecked="{Binding Path=Singleline}" IsEnabled="{Binding Path=IsSinglelineEnabled}">Match dot as newline</CheckBox>
+                            <CheckBox Margin="-3,4,3,3" Name="cbCaseSensitive" IsChecked="{Binding Path=CaseSensitive}" IsEnabled="{Binding Path=IsCaseSensitiveEnabled}" VerticalContentAlignment="Center" VerticalAlignment="Center">Case sensitive</CheckBox>
+                            <CheckBox Margin="3,4,3,3" Name="cbWholeWord" IsChecked="{Binding Path=WholeWord}" IsEnabled="{Binding Path=IsWholeWordEnabled}" VerticalContentAlignment="Center" VerticalAlignment="Center">Whole word</CheckBox>
+                            <CheckBox Margin="3,4,3,3" Name="cbMultiline" IsChecked="{Binding Path=Multiline}" IsEnabled="{Binding Path=IsMultilineEnabled}" VerticalContentAlignment="Center" VerticalAlignment="Center">Multiline (slower)</CheckBox>
+                            <CheckBox Margin="3,4,3,3" Name="cbSingleline" IsChecked="{Binding Path=Singleline}" IsEnabled="{Binding Path=IsSinglelineEnabled}" VerticalContentAlignment="Center" VerticalAlignment="Center">Dot matches newline</CheckBox>
                         </StackPanel>
-                    </Expander>
+                    </GroupBox>
                 </Grid>
             </GroupBox>
         </StackPanel>
@@ -115,10 +109,10 @@
                 <RowDefinition Height="30" />
                 <RowDefinition Height="25" />
             </Grid.RowDefinitions>
-            <Label Grid.Row="0" >Sample input text:</Label>
+            <Label Grid.Row="0" Margin="0" VerticalContentAlignment="Center" VerticalAlignment="Center" >Sample input text:</Label>
             <TextBox Grid.Row="1" Margin="5" AcceptsReturn="True"  Height="Auto" Name="tbTestInput" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" 
                      Text="{Binding Path=SampleText, UpdateSourceTrigger=PropertyChanged}"></TextBox>
-            <Label Grid.Row="2" >Output text:</Label>
+            <Label Grid.Row="2" VerticalContentAlignment="Center" VerticalAlignment="Center" >Output text:</Label>
             <ScrollViewer Grid.Row="3" Margin="5" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                 <my:InlineTextBlock Margin="3,0,0,0" InlineCollection="{Binding TestOutput}" FontFamily="Consolas">
                     <my:InlineTextBlock.ContextMenu>
@@ -129,12 +123,12 @@
                 </my:InlineTextBlock>
             </ScrollViewer>
             <StackPanel Grid.Row="4" Margin="0,0,3,0"  HorizontalAlignment="Right" Orientation="Horizontal">
-                <Button Width="64" Margin="0,3,0,3" x:Name="btnSearch" Content="Search" Command="{Binding SearchCommand}" IsDefault="True" />
-                <Button Width="64" Margin="3" Content="Replace" Name="btnReplace" Command="{Binding ReplaceCommand}"/>
-                <Button Width="64" Margin="0,3,0,3" x:Name="btnClose" Content="Close" Click="btnClose_Click" IsCancel="True" />
+                <Button Width="64" Margin="3" x:Name="btnSearch" Content="Search" Command="{Binding SearchCommand}" IsDefault="True" Height="24" VerticalAlignment="Center" />
+                <Button Width="64" Margin="3" Content="Replace" Name="btnReplace" Command="{Binding ReplaceCommand}" Height="24" VerticalAlignment="Center"/>
+                <Button Width="64" Margin="3" x:Name="btnClose" Content="Close" Click="btnClose_Click" IsCancel="True" Height="24" VerticalAlignment="Center" />
             </StackPanel>
             <StatusBar Grid.Row="5" ClipToBounds="False" BorderThickness="1" BorderBrush="DarkGray">
-                <TextBlock Name="lblStatus">Click Search or Replace to test search pattern</TextBlock>
+                <TextBlock Name="lblStatus" VerticalAlignment="Center" HorizontalAlignment="Center">Click Search or Replace to test search pattern</TextBlock>
             </StatusBar>
         </Grid>
     </DockPanel>


### PR DESCRIPTION
Automatically select the "Search for" text on windows load if the textbox is already filled so that we can just start typing for a new search without having to click on the text.

It is useful when doing a right click on a folder for a new search.