### PR TITLE
Issue #277 utf-8 byte order mark

### DIFF
--- a/Tests/Files/TestCase15/books.xml
+++ b/Tests/Files/TestCase15/books.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+  <book category="cooking">
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price currency="USD">30.00</price>
+  </book>
+  <book category="children">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price currency="USD">29.99</price>
+  </book>
+  <book category="web">
+    <title lang="en">XQuery Kick Start</title>
+    <author>James McGovern</author>
+    <author>Per Bothner</author>
+    <author>Kurt Cagle</author>
+    <author>James Linn</author>
+    <author>Vaidyanathan Nagarajan</author>
+    <year>2003</year>
+    <price currency="USD">49.99</price>
+  </book>
+  <book category="web">
+    <title lang="en">Learning XML</title>
+    <author>Erik T. Ray</author>
+    <year>2003</year>
+    <price currency="USD">39.95</price>
+  </book>
+  <book category="programming">
+    <title lang="en">grep Pocket Reference</title>
+    <author>John Bambenek</autho>
+    <author>Agnieszka Klus</author>
+    <year>2009</year>
+    <price currency="USD">8.99</price>
+  </book>
+</bookstore>

--- a/Tests/Files/TestCase15/books_bom.xml
+++ b/Tests/Files/TestCase15/books_bom.xml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+  <book category="cooking">
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price currency="USD">30.00</price>
+  </book>
+  <book category="children">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price currency="USD">29.99</price>
+  </book>
+  <book category="web">
+    <title lang="en">XQuery Kick Start</title>
+    <author>James McGovern</author>
+    <author>Per Bothner</author>
+    <author>Kurt Cagle</author>
+    <author>James Linn</author>
+    <author>Vaidyanathan Nagarajan</author>
+    <year>2003</year>
+    <price currency="USD">49.99</price>
+  </book>
+  <book category="web">
+    <title lang="en">Learning XML</title>
+    <author>Erik T. Ray</author>
+    <year>2003</year>
+    <price currency="USD">39.95</price>
+  </book>
+  <book category="programming">
+    <title lang="en">grep Pocket Reference</title>
+    <author>John Bambenek</autho>
+    <author>Agnieszka Klus</author>
+    <year>2009</year>
+    <price currency="USD">8.99</price>
+  </book>
+</bookstore>

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -1736,6 +1736,26 @@ namespace dnGREP.Common
 
             return durationStringBuilder.ToString();
         }
+
+        public static bool HasUtf8ByteOrderMark(Stream inputStream)
+        {
+            bool result = false;
+            int bb = inputStream.ReadByte();
+            if (0xEF == bb)
+            {
+                bb = inputStream.ReadByte();
+                if (0xBB == bb)
+                {
+                    bb = inputStream.ReadByte();
+                    if (0xBF == bb)
+                    {
+                        result = true;
+                    }
+                }
+            }
+            inputStream.Seek(0, SeekOrigin.Begin);
+            return result;
+        }
     }
 
     public class KeyValueComparer : IComparer<KeyValuePair<string, int>>

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -1739,22 +1739,12 @@ namespace dnGREP.Common
 
         public static bool HasUtf8ByteOrderMark(Stream inputStream)
         {
-            bool result = false;
-            int bb = inputStream.ReadByte();
-            if (0xEF == bb)
-            {
-                bb = inputStream.ReadByte();
-                if (0xBB == bb)
-                {
-                    bb = inputStream.ReadByte();
-                    if (0xBF == bb)
-                    {
-                        result = true;
-                    }
-                }
-            }
+            int b1 = inputStream.ReadByte();
+            int b2 = inputStream.ReadByte();
+            int b3 = inputStream.ReadByte();
             inputStream.Seek(0, SeekOrigin.Begin);
-            return result;
+
+            return (0xEF == b1 && 0xBB == b2 && 0xBF == b3);
         }
     }
 


### PR DESCRIPTION
Issue #277 change to keep original file utf-8 bom.  Also fixed a problem where the "replace" added an extra new line to files that did not end with a new line.  

I believe this fixes the current problem, but we could use more tests for replace on files with different encodings.

For Issue #210, added an additional fix for regex replace, where the regex contains a $ token.  The $ (end of line) token will only match UNIX new line character, so Windows and Mac new lines must be converted to the UNIX new line before calling the replace method.