### PR TITLE
Set security protocol flags to enable TLS 1.2 for GitHub connection

### DIFF
--- a/dnGREP.Common/PublishedVersionExtractor.cs
+++ b/dnGREP.Common/PublishedVersionExtractor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -15,6 +16,10 @@ namespace dnGREP.Common
 
             using (var client = new HttpClient())
             {
+                // TLS 1.2 is required for GitHub connection after 2/1/2018
+                // https://githubengineering.com/crypto-deprecation-notice/
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
                 client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "http://developer.github.com/v3/#user-agent-required");
                 using (HttpResponseMessage response = await client.GetAsync(page))
                 {


### PR DESCRIPTION
The check for new versions utility in dnGrep has stopped working because GitHub removed support for TLS 1.1.   Added flag to enable TLS 1.2 in the code