### PR TITLE
Find files

### DIFF
--- a/AssemblyInfoCommon.cs
+++ b/AssemblyInfoCommon.cs
@@ -4,6 +4,6 @@ using System.Reflection;
 // AssemblyCompany name is used for AppData\Local\ directory name
 [assembly: AssemblyCompany("dnGrep")]
 [assembly: AssemblyProduct("dnGREP")]
-[assembly: AssemblyCopyright("Copyright 2013, 2018 Denis Stankovski")]
+[assembly: AssemblyCopyright("Copyright 2013, 2018 dnGrep Community Contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Tests/GrepCoreTest.cs
+++ b/Tests/GrepCoreTest.cs
@@ -368,7 +368,7 @@ namespace Tests
         {
             Utils.CopyFiles(sourceFolder + "\\TestCase14", destinationFolder + "\\TestCase14", null, null);
             GrepCore core = new GrepCore();
-            core.SearchParams = new GrepEngineInitParams(false, 0, 0, 0.5, verbose);
+            core.SearchParams = new GrepEngineInitParams(false, 0, 0, 0.5, verbose, false);
             Stopwatch sw = new Stopwatch();
             sw.Start();
             List<GrepSearchResult> results = core.Search(Directory.GetFiles(destinationFolder + "\\TestCase14", "*.txt"), type, "1234", option, -1);

--- a/Tests/GrepCoreTest.cs
+++ b/Tests/GrepCoreTest.cs
@@ -376,7 +376,7 @@ namespace Tests
             Assert.Equal(2, results.Count);
             Assert.Equal(102456, results[0].Matches.Count);
             Assert.Equal(102456, results[1].Matches.Count);
-            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1.25));
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2.0));
         }
 
         [Fact]

--- a/Tests/UtilsTest.cs
+++ b/Tests/UtilsTest.cs
@@ -811,11 +811,11 @@ namespace Tests
         {
             string dllPath = GetDllPath();
             string path = sourceFolder + "\\TestCase2";
-            Assert.Equal(Utils.GetFileList(path, "*.*", "*.xls", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length, 3);
-            Assert.Equal(Utils.GetFileList(path, "excel*.*", "*.xls", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length, 0);
-            Assert.Equal(Utils.GetFileList(path, "excel*.*", "*.xs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length, 1);
-            Assert.Equal(Utils.GetFileList(path, "t[a-z]st-file-*.*", "*.cs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length, 2);
-            Assert.Equal(Utils.GetFileList(path, "t[ea]st-file-*.*", "*.cs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length, 2);
+            Assert.Equal(3, Utils.GetFileList(path, "*.*", "*.xls", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length);
+            Assert.Equal(0, Utils.GetFileList(path, "excel*.*", "*.xls", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length);
+            Assert.Equal(1, Utils.GetFileList(path, "excel*.*", "*.xs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length);
+            Assert.Equal(2, Utils.GetFileList(path, "t*st-file-*.*", "*.cs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length);
+            Assert.Equal(2, Utils.GetFileList(path, "t?st-file-*.*", "*.cs", false, false, false, true, false, 0, 0, FileDateFilter.None, null, null).Length);
         }
 
         [Fact]

--- a/dnGREP.ArchiveEngine/GrepEngineArchive.cs
+++ b/dnGREP.ArchiveEngine/GrepEngineArchive.cs
@@ -98,6 +98,8 @@ namespace dnGREP.Engines.Archive
                                             searchResults.AddRange(innerFileResults);
                                         }
                                     }
+
+                                    GrepEngineFactory.ReturnToPool(innerFileName, engine);
                                 }
                                 if (Utils.CancelSearch)
                                     break;

--- a/dnGREP.Common/GrepApplicationSettings.cs
+++ b/dnGREP.Common/GrepApplicationSettings.cs
@@ -102,6 +102,10 @@ namespace dnGREP.Common
             public const string HoursFrom = "HoursFrom";
             [DefaultValue(8)]
             public const string HoursTo = "HoursTo";
+            [DefaultValue(false)]
+            public const string SearchParallel = "SearchParallel";
+            [DefaultValue(4.0)]
+            public const string MatchTimeout = "MatchTimeout";
         }
 
         private static GrepSettings instance;

--- a/dnGREP.Common/GrepApplicationSettings.cs
+++ b/dnGREP.Common/GrepApplicationSettings.cs
@@ -102,7 +102,7 @@ namespace dnGREP.Common
             public const string HoursFrom = "HoursFrom";
             [DefaultValue(8)]
             public const string HoursTo = "HoursTo";
-            [DefaultValue(false)]
+            [DefaultValue(true)]
             public const string SearchParallel = "SearchParallel";
             [DefaultValue(4.0)]
             public const string MatchTimeout = "MatchTimeout";
@@ -132,7 +132,7 @@ namespace dnGREP.Common
         /// </summary>
         public void Load()
         {
-            Load(Utils.GetDataFolderPath() + "\\" + storageFileName);
+            Load(Path.Combine(Utils.GetDataFolderPath(), storageFileName));
         }
 
         /// <summary>

--- a/dnGREP.Common/SafeDirectory.cs
+++ b/dnGREP.Common/SafeDirectory.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NLog;
+
+namespace dnGREP.Common
+{
+    public static class SafeDirectory
+    {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        public static IEnumerable<string> EnumerateDirectories(string path, string pattern, SearchOption option)
+        {
+            return EnumerateDirectories(new DirectoryInfo(path), pattern, option);
+        }
+
+        public static IEnumerable<string> EnumerateDirectories(DirectoryInfo root, string pattern, SearchOption option)
+        {
+            if (root == null || !root.Exists) yield break;
+
+            IEnumerable<DirectoryInfo> matches = Enumerable.Empty<DirectoryInfo>();
+            try
+            {
+                matches = matches.Concat(root.EnumerateDirectories(pattern, SearchOption.TopDirectoryOnly));
+            }
+            catch (UnauthorizedAccessException)
+            {
+                logger.Warn(string.Format(@"Unable to access '{0}'. Skipping...", root.FullName));
+                yield break;
+            }
+            catch (PathTooLongException ptle)
+            {
+                logger.Warn(ptle, string.Format(@"Could not process path '{0}\{1}'.", root.Parent.FullName, root.Name));
+                yield break;
+            }
+            catch (IOException ioe)
+            {
+                // "The symbolic link cannot be followed because its type is disabled."
+                // "The specified network name is no longer available."
+                logger.Warn(ioe, string.Format(@"Could not process path (check SymlinkEvaluation rules) '{0}\{1}'.", root.Parent.FullName, root.Name));
+                yield break;
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, string.Format(@"Could not process path '{0}\{1}'.", root.Parent.FullName, root.Name));
+                yield break;
+            }
+
+
+            foreach (var dir in matches)
+            {
+                yield return dir.FullName;
+            }
+
+            if (option == SearchOption.AllDirectories)
+            {
+                foreach (var subdir in root.EnumerateDirectories("*", SearchOption.TopDirectoryOnly))
+                {
+                    foreach (var match in EnumerateDirectories(subdir, pattern, option))
+                    {
+                        yield return match;
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<string> EnumerateFiles(string path, IEnumerable<string> patterns)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path)) yield break;
+
+            IEnumerable<string> matches = Enumerable.Empty<string>();
+            try
+            {
+                if (patterns.Any())
+                {
+                    foreach (var pattern in patterns)
+                        matches = matches.Concat(Directory.EnumerateFiles(path, pattern));
+                }
+                else
+                {
+                    matches = matches.Concat(Directory.EnumerateFiles(path));
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                logger.Warn(string.Format(@"Unable to access '{0}'. Skipping...", path));
+                yield break;
+            }
+            catch (PathTooLongException ptle)
+            {
+                logger.Warn(ptle, string.Format(@"Could not process file in path '{0}'.", path));
+                yield break;
+            }
+            catch (IOException ioe)
+            {
+                // "The symbolic link cannot be followed because its type is disabled."
+                // "The specified network name is no longer available."
+                logger.Warn(ioe, string.Format(@"Could not process path (check SymlinkEvaluation rules)'{0} '.", path));
+                yield break;
+            }
+            catch (Exception ex)
+            {
+                logger.Warn(ex, string.Format(@"Could not process path '{0}'.", path));
+                yield break;
+            }
+
+
+            foreach (var file in matches)
+            {
+                yield return file;
+            }
+
+        }
+    }
+}

--- a/dnGREP.Common/Ude.Core/UniversalDetector.cs
+++ b/dnGREP.Common/Ude.Core/UniversalDetector.cs
@@ -174,7 +174,7 @@ namespace Ude.Core
                     for (int i = 0; i < PROBERS_NUM; i++) {
                         if (charsetProbers[i] != null) {
                             st = charsetProbers[i].HandleData(buf, offset, len);
-                            #if DEBUG                            
+                            #if DEBUG_UDE
                             charsetProbers[i].DumpStatus();
                             #endif                        
                             if (st == ProbingState.FoundIt) {

--- a/dnGREP.Common/Ude.Core/UniversalDetector.cs
+++ b/dnGREP.Common/Ude.Core/UniversalDetector.cs
@@ -174,9 +174,9 @@ namespace Ude.Core
                     for (int i = 0; i < PROBERS_NUM; i++) {
                         if (charsetProbers[i] != null) {
                             st = charsetProbers[i].HandleData(buf, offset, len);
-                            #if DEBUG_UDE
+#if DEBUG_ENCODING_DETECTION
                             charsetProbers[i].DumpStatus();
-                            #endif                        
+#endif
                             if (st == ProbingState.FoundIt) {
                                 done = true;
                                 detectedCharset = charsetProbers[i].GetCharsetName();

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -700,7 +700,6 @@ namespace dnGREP.Common
                     {
                         regex = new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
                         regexCache.Add(pattern, regex);
-                        Debug.WriteLine("Added " + pattern);
                     }
                 }
                 catch (Exception ex)

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -452,7 +452,7 @@ namespace dnGREP.Common
             if (!string.IsNullOrWhiteSpace(ext) &&
                 (ext.Equals(".XLS", StringComparison.CurrentCultureIgnoreCase) ||
                  ext.Equals(".XLSX", StringComparison.CurrentCultureIgnoreCase) ||
-                 ext.Equals(".XLSM", StringComparison.OrdinalIgnoreCase)))
+                 ext.Equals(".XLSM", StringComparison.CurrentCultureIgnoreCase)))
                 return true;
             return false;
         }
@@ -784,16 +784,15 @@ namespace dnGREP.Common
                             if (!filter.IncludeArchive && IsArchive(filePath))
                                 continue;
 
-                            if (!IsArchive(filePath) && !filter.IncludeBinary)
+                            if (!filter.IncludeBinary && !IsArchive(filePath))
                             {
-                                // when searching for Excel and Word files, skip the binary file check
-                                if (IsExcelFile(filePath) && includeSearchPatterns.Contains(".xls", StringComparison.OrdinalIgnoreCase))
-                                {
-                                }
-                                else if (IsWordFile(filePath) && includeSearchPatterns.Contains(".doc", StringComparison.OrdinalIgnoreCase))
-                                {
-                                }
-                                else if (IsBinary(filePath))
+                                bool isExcelMatch = IsExcelFile(filePath) && includeSearchPatterns.Contains(".xls", StringComparison.OrdinalIgnoreCase);
+                                bool isWordMatch = IsWordFile(filePath) && includeSearchPatterns.Contains(".doc", StringComparison.OrdinalIgnoreCase);
+                                
+                                // When searching for Excel and Word files, skip the binary file check:
+                                // If someone is searching for Excel or Word, don't make them include binary to 
+                                // find their files.  No need to include PDF, it doesn't test positive as a binary file.
+                                if (!(isExcelMatch || isWordMatch) && IsBinary(filePath))
                                 {
                                     continue;
                                 }

--- a/dnGREP.Common/dnGREP.Common.csproj
+++ b/dnGREP.Common/dnGREP.Common.csproj
@@ -122,6 +122,7 @@
     <Compile Include="BookmarkLibrary.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="FileFilter.cs" />
+    <Compile Include="SafeDirectory.cs" />
     <Compile Include="GrepSearchResult.cs" />
     <Compile Include="EolReader.cs" />
     <Compile Include="OpenFileArgs.cs" />

--- a/dnGREP.Engines/GrepCore.cs
+++ b/dnGREP.Engines/GrepCore.cs
@@ -77,7 +77,7 @@ namespace dnGREP.Common
                         cancellationTokenSource = new CancellationTokenSource();
 
                         ParallelOptions po = new ParallelOptions();
-                        //po.MaxDegreeOfParallelism = Environment.ProcessorCount * 4 / 5;
+                        po.MaxDegreeOfParallelism = Environment.ProcessorCount * 4 / 5;
                         po.CancellationToken = cancellationTokenSource.Token;
                         Parallel.ForEach(files, po, f => Search(f, searchType, searchPattern, searchOptions, codePage));
                     }

--- a/dnGREP.Engines/GrepCore.cs
+++ b/dnGREP.Engines/GrepCore.cs
@@ -166,6 +166,8 @@ namespace dnGREP.Common
                 Interlocked.Add(ref foundfilesCount, hits);
 
                 ProcessedFile(this, new ProgressStatus(false, processedFilesCount, foundfilesCount, fileSearchResults, file));
+
+                GrepEngineFactory.ReturnToPool(file, engine);
             }
             catch (Exception ex)
             {
@@ -238,6 +240,8 @@ namespace dnGREP.Common
 
 
                         File.SetAttributes(file, File.GetAttributes(tempFileName));
+
+                        GrepEngineFactory.ReturnToPool(file, engine);
 
                         if (Utils.CancelSearch)
                         {

--- a/dnGREP.Engines/GrepCore.cs
+++ b/dnGREP.Engines/GrepCore.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using dnGREP.Engines;
 using NLog;
 
@@ -9,9 +12,14 @@ namespace dnGREP.Common
 {
     public class GrepCore
     {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        public delegate void SearchProgressHandler(object sender, ProgressStatus files);
+        public event SearchProgressHandler ProcessedFile = delegate { };
+
         public GrepCore()
         {
-            SearchParams = new GrepEngineInitParams();
+            SearchParams = GrepEngineInitParams.Default;
             FileFilter = new FileFilter();
         }
 
@@ -19,22 +27,11 @@ namespace dnGREP.Common
         public FileFilter FileFilter { get; set; }
 
 
-        private static Logger logger = LogManager.GetCurrentClassLogger();
         private List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
-        public delegate void SearchProgressHandler(object sender, ProgressStatus files);
-        public event SearchProgressHandler ProcessedFile = delegate { };
-        public class ProgressStatus
-        {
-            public ProgressStatus(int processed, List<GrepSearchResult> results, string fileName)
-            {
-                ProcessedFiles = processed;
-                SearchResults = results;
-                FileName = fileName;
-            }
-            public int ProcessedFiles;
-            public List<GrepSearchResult> SearchResults;
-            public string FileName;
-        }
+        private object lockObj = new object();
+        private CancellationTokenSource cancellationTokenSource;
+        private int processedFilesCount;
+        private int foundfilesCount;
 
         /// <summary>
         /// Searches folder for files whose content matches regex
@@ -44,7 +41,7 @@ namespace dnGREP.Common
         /// <returns>List of results. If nothing is found returns empty list</returns>
         public List<GrepSearchResult> Search(IEnumerable<string> files, SearchType searchType, string searchPattern, GrepSearchOption searchOptions, int codePage)
         {
-            List<GrepSearchResult> searchResults = new List<GrepSearchResult>();
+            searchResults.Clear();
 
             if (files == null)
                 return searchResults;
@@ -55,7 +52,7 @@ namespace dnGREP.Common
             {
                 foreach (string file in files)
                 {
-                    ProcessedFile(this, new ProgressStatus(searchResults.Count, null, file));
+                    ProcessedFile(this, new ProgressStatus(true, searchResults.Count, files.Count(), null, file));
 
                     searchResults.Add(new GrepSearchResult(file, searchPattern, null, Encoding.Default));
                     if ((searchOptions & GrepSearchOption.StopAfterFirstMatch) == GrepSearchOption.StopAfterFirstMatch)
@@ -64,67 +61,130 @@ namespace dnGREP.Common
                         break;
                 }
 
-                ProcessedFile(this, new ProgressStatus(searchResults.Count, searchResults, null));
+                ProcessedFile(this, new ProgressStatus(false, searchResults.Count, files.Count(), searchResults, null));
 
-                return searchResults;
+                return new List<GrepSearchResult>(searchResults);
             }
             else
             {
-                int processedFiles = 0;
+                processedFilesCount = 0;
+                foundfilesCount = 0;
 
                 try
                 {
-                    foreach (string file in files)
+                    if (SearchParams.SearchParallel)
                     {
-                        ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
-                        try
-                        {
-                            IGrepEngine engine = GrepEngineFactory.GetSearchEngine(file, SearchParams, FileFilter);
+                        cancellationTokenSource = new CancellationTokenSource();
 
-                            processedFiles++;
-
-                            Encoding encoding = Encoding.Default;
-                            if (codePage > -1)
-                                encoding = Encoding.GetEncoding(codePage);
-                            else if (!Utils.IsBinary(file) && !Utils.IsPdfFile(file))
-                                encoding = Utils.GetFileEncoding(file);
-
-                            if (Utils.CancelSearch)
-                            {
-                                return searchResults;
-                            }
-
-                            List<GrepSearchResult> fileSearchResults = engine.Search(file, searchPattern, searchType, searchOptions, encoding);
-
-                            if (fileSearchResults != null && fileSearchResults.Count > 0)
-                            {
-                                searchResults.AddRange(fileSearchResults);
-                            }
-
-                            ProcessedFile(this, new ProgressStatus(processedFiles, fileSearchResults, file));
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.Log<Exception>(LogLevel.Error, ex.Message, ex);
-                            searchResults.Add(new GrepSearchResult(file, searchPattern, ex.Message, false));
-                            if (ProcessedFile != null)
-                            {
-                                List<GrepSearchResult> _results = new List<GrepSearchResult>();
-                                _results.Add(new GrepSearchResult(file, searchPattern, ex.Message, false));
-                                ProcessedFile(this, new ProgressStatus(processedFiles, _results, file));
-                            }
-                        }
-
-                        if ((searchOptions & GrepSearchOption.StopAfterFirstMatch) == GrepSearchOption.StopAfterFirstMatch && searchResults.Count > 0)
-                            break;
+                        ParallelOptions po = new ParallelOptions();
+                        //po.MaxDegreeOfParallelism = Environment.ProcessorCount * 4 / 5;
+                        po.CancellationToken = cancellationTokenSource.Token;
+                        Parallel.ForEach(files, po, f => Search(f, searchType, searchPattern, searchOptions, codePage));
                     }
+                    else
+                    {
+                        foreach (var file in files)
+                        {
+                            Search(file, searchType, searchPattern, searchOptions, codePage);
+
+                            if ((searchOptions & GrepSearchOption.StopAfterFirstMatch) == GrepSearchOption.StopAfterFirstMatch && searchResults.Count > 0)
+                                break;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected for stop after first match or user cancel
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Failed in search in files");
                 }
                 finally
                 {
+                    if (cancellationTokenSource != null)
+                    {
+                        cancellationTokenSource.Dispose();
+                        cancellationTokenSource = null;
+                    }
                     GrepEngineFactory.UnloadEngines();
                 }
 
-                return searchResults;
+                return new List<GrepSearchResult>(searchResults);
+            }
+        }
+
+        private void AddSearchResult(GrepSearchResult result)
+        {
+            lock (lockObj)
+            {
+                searchResults.Add(result);
+            }
+        }
+
+        private void AddSearchResults(IEnumerable<GrepSearchResult> results)
+        {
+            lock (lockObj)
+            {
+                if (results.Any())
+                {
+                    searchResults.AddRange(results);
+                }
+            }
+        }
+
+        private void Search(string file, SearchType searchType, string searchPattern, GrepSearchOption searchOptions, int codePage)
+        {
+            try
+            {
+                ProcessedFile(this, new ProgressStatus(true, processedFilesCount, foundfilesCount, null, file));
+
+                IGrepEngine engine = GrepEngineFactory.GetSearchEngine(file, SearchParams, FileFilter);
+
+                Interlocked.Increment(ref processedFilesCount);
+
+                Encoding encoding = Encoding.Default;
+                if (codePage > -1)
+                    encoding = Encoding.GetEncoding(codePage);
+                else if (!Utils.IsBinary(file) && !Utils.IsPdfFile(file))
+                    encoding = Utils.GetFileEncoding(file);
+
+                if (Utils.CancelSearch)
+                {
+                    if (cancellationTokenSource != null)
+                        cancellationTokenSource.Cancel();
+                    return;
+                }
+
+                List<GrepSearchResult> fileSearchResults = engine.Search(file, searchPattern, searchType, searchOptions, encoding);
+
+                if (fileSearchResults != null && fileSearchResults.Count > 0)
+                {
+                    AddSearchResults(fileSearchResults);
+                }
+                int hits = fileSearchResults.Where(r => r.IsSuccess).Count();
+                Interlocked.Add(ref foundfilesCount, hits);
+
+                ProcessedFile(this, new ProgressStatus(false, processedFilesCount, foundfilesCount, fileSearchResults, file));
+            }
+            catch (Exception ex)
+            {
+                logger.Log<Exception>(LogLevel.Error, ex.Message, ex);
+                AddSearchResult(new GrepSearchResult(file, searchPattern, ex.Message, false));
+                if (ProcessedFile != null)
+                {
+                    List<GrepSearchResult> _results = new List<GrepSearchResult>();
+                    _results.Add(new GrepSearchResult(file, searchPattern, ex.Message, false));
+                    ProcessedFile(this, new ProgressStatus(false, processedFilesCount, foundfilesCount, _results, file));
+                }
+            }
+            finally
+            {
+                if ((searchOptions & GrepSearchOption.StopAfterFirstMatch) == GrepSearchOption.StopAfterFirstMatch && searchResults.Count > 0)
+                {
+                    if (cancellationTokenSource != null)
+                        cancellationTokenSource.Cancel();
+                }
             }
         }
 
@@ -145,7 +205,7 @@ namespace dnGREP.Common
             {
                 foreach (string file in files)
                 {
-                    ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
+                    ProcessedFile(this, new ProgressStatus(true, processedFiles, processedFiles, null, file));
 
                     tempFileName = Path.Combine(tempFolder, Path.GetFileName(file));
                     IGrepEngine engine = GrepEngineFactory.GetReplaceEngine(file, SearchParams, FileFilter);
@@ -174,7 +234,7 @@ namespace dnGREP.Common
                         }
 
                         if (!Utils.CancelSearch)
-                            ProcessedFile(this, new ProgressStatus(processedFiles, null, file));
+                            ProcessedFile(this, new ProgressStatus(false, processedFiles, processedFiles, null, file));
 
 
                         File.SetAttributes(file, File.GetAttributes(tempFileName));
@@ -246,5 +306,22 @@ namespace dnGREP.Common
                 return false;
             }
         }
+    }
+
+    public class ProgressStatus
+    {
+        public ProgressStatus(bool beginSearch, int processed, int successful, List<GrepSearchResult> results, string fileName)
+        {
+            BeginSearch = beginSearch;
+            ProcessedFiles = processed;
+            SuccessfulFiles = successful;
+            SearchResults = results;
+            FileName = fileName;
+        }
+        public bool BeginSearch { get; private set; }
+        public int ProcessedFiles { get; private set; }
+        public int SuccessfulFiles { get; private set; }
+        public List<GrepSearchResult> SearchResults { get; private set; }
+        public string FileName { get; private set; }
     }
 }

--- a/dnGREP.Engines/GrepEngineBase.cs
+++ b/dnGREP.Engines/GrepEngineBase.cs
@@ -14,8 +14,10 @@ namespace dnGREP.Engines
         private string KEYWORD_GUID_LOWER = "$(guid)";
         private string KEYWORD_GUID_UPPER = "$(GUID)";
         private string KEYWORD_GUIDX = "$(guidx)";
-        protected GrepEngineInitParams initParams = new GrepEngineInitParams();
+        protected GrepEngineInitParams initParams = GrepEngineInitParams.Default;
         private GoogleMatch fuzzyMatchEngine = new GoogleMatch();
+
+        public static TimeSpan MatchTimeout = TimeSpan.FromSeconds(4.0);
 
         public GrepEngineBase()
         {
@@ -398,7 +400,7 @@ namespace dnGREP.Engines
             var lineEndIndexes = GetLineEndIndexes((initParams.VerboseMatchCount && lineNumber == -1) ? text : null);
 
             List<GrepSearchResult.GrepMatch> globalMatches = new List<GrepSearchResult.GrepMatch>();
-            var matches = Regex.Matches(text, searchPattern, regexOptions);
+            var matches = Regex.Matches(text, searchPattern, regexOptions, MatchTimeout);
             foreach (Match match in matches)
             {
                 if (initParams.VerboseMatchCount && lineEndIndexes.Count > 0)
@@ -425,7 +427,7 @@ namespace dnGREP.Engines
             int lineNumber = 1;
 
             List<GrepSearchResult.GrepMatch> globalMatches = new List<GrepSearchResult.GrepMatch>();
-            var matches = Regex.Matches(text, searchPattern, regexOptions);
+            var matches = Regex.Matches(text, searchPattern, regexOptions, MatchTimeout);
             foreach (Match match in matches)
             {
                 if (lineEndIndexes.Count > 0)
@@ -703,6 +705,8 @@ namespace dnGREP.Engines
 
     public class GrepEngineInitParams
     {
+        public static GrepEngineInitParams Default = new GrepEngineInitParams();
+
         public GrepEngineInitParams()
         {
             ShowLinesInContext = false;
@@ -710,9 +714,11 @@ namespace dnGREP.Engines
             LinesAfter = 0;
             FuzzyMatchThreshold = 0.5f;
             VerboseMatchCount = false;
+            // keep the default false: for unit tests and maintain previous behavior 
+            SearchParallel = false;
         }
 
-        public GrepEngineInitParams(bool showLinesInContext, int linesBefore, int linesAfter, double fuzzyMatchThreshold, bool verboseMatchCount)
+        public GrepEngineInitParams(bool showLinesInContext, int linesBefore, int linesAfter, double fuzzyMatchThreshold, bool verboseMatchCount, bool searchParallel)
         {
             ShowLinesInContext = showLinesInContext;
             if (!showLinesInContext)
@@ -727,6 +733,7 @@ namespace dnGREP.Engines
             }
             FuzzyMatchThreshold = (float)fuzzyMatchThreshold;
             VerboseMatchCount = verboseMatchCount;
+            SearchParallel = searchParallel;
         }
 
         public bool ShowLinesInContext { get; private set; }
@@ -734,5 +741,6 @@ namespace dnGREP.Engines
         public int LinesAfter { get; private set; }
         public float FuzzyMatchThreshold { get; private set; }
         public bool VerboseMatchCount { get; private set; }
+        public bool SearchParallel { get; private set; }
     }
 }

--- a/dnGREP.Engines/GrepEngineBase.cs
+++ b/dnGREP.Engines/GrepEngineBase.cs
@@ -714,7 +714,7 @@ namespace dnGREP.Engines
             LinesAfter = 0;
             FuzzyMatchThreshold = 0.5f;
             VerboseMatchCount = false;
-            // keep the default false: for unit tests and maintain previous behavior 
+            // keep the default false for unit tests 
             SearchParallel = false;
         }
 

--- a/dnGREP.Engines/GrepEngineFactory.cs
+++ b/dnGREP.Engines/GrepEngineFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using dnGREP.Common;
 using NLog;
@@ -11,39 +12,87 @@ namespace dnGREP.Engines
 {
     public class GrepEngineFactory
     {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
         private static Dictionary<string, GrepPlugin> fileTypeEngines = new Dictionary<string, GrepPlugin>();
         private static List<GrepPlugin> plugins = null;
+        private static Dictionary<string, string> poolKeys = new Dictionary<string, string>();
+        private static List<IGrepEngine> loadedEngines = new List<IGrepEngine>();
+        private static Dictionary<string, Queue<IGrepEngine>> pooledEngines = new Dictionary<string, Queue<IGrepEngine>>();
         private static Dictionary<string, string> failedEngines = new Dictionary<string, string>();
-        private static Logger logger = LogManager.GetCurrentClassLogger();
+        private static object lockObj = new object();
 
         private static void LoadPlugins()
         {
-            if (plugins == null)
+            lock (lockObj)
             {
-                plugins = new List<GrepPlugin>();
-                string pluginPath = Path.Combine(Utils.GetCurrentPath(), "Plugins");
-                if (Directory.Exists(pluginPath))
+                if (plugins == null)
                 {
-                    foreach (string pluginFile in Directory.GetFiles(pluginPath, "*.plugin", SearchOption.AllDirectories))
+                    plugins = new List<GrepPlugin>();
+                    string pluginPath = Path.Combine(Utils.GetCurrentPath(), "Plugins");
+                    if (Directory.Exists(pluginPath))
                     {
-                        try
+                        foreach (string pluginFile in Directory.GetFiles(pluginPath, "*.plugin", SearchOption.AllDirectories))
                         {
-                            GrepPlugin plugin = new GrepPlugin(pluginFile);
-                            if (plugin.LoadPluginSettings() && plugin.Enabled)
+                            try
                             {
-                                logger.Debug(string.Format("Loading plugin: {0} for extensions {1}",
-                                    plugin.DllFilePath, string.Join(", ", plugin.Extensions.ToArray())));
-                                plugins.Add(plugin);
+                                GrepPlugin plugin = new GrepPlugin(pluginFile);
+                                if (plugin.LoadPluginSettings())
+                                {
+                                    if (plugin.Enabled)
+                                    {
+                                        if (FrameworkVersionsAreCompatible(plugin.FrameworkVersion, FrameworkVersion))
+                                        {
+                                            plugins.Add(plugin);
+
+                                            // many file extensions will map to the same pool of engines, 
+                                            // so keep a common key for the set of extensions
+                                            foreach (string ext in plugin.Extensions)
+                                            {
+                                                string fileExtension = ext.TrimStart('.');
+                                                if (!poolKeys.ContainsKey(fileExtension))
+                                                {
+                                                    poolKeys.Add(fileExtension, plugin.PluginName);
+                                                }
+                                            }
+
+                                            logger.Debug(string.Format("Loading plugin: {0} for extensions {1}",
+                                                plugin.DllFilePath, string.Join(", ", plugin.Extensions.ToArray())));
+                                        }
+                                        else
+                                        {
+                                            logger.Error(string.Format("Plugin '{0}' developed under outdated framework. Please update the plugin.", Path.GetFileNameWithoutExtension(pluginFile)));
+                                        }
+                                    }
+                                    else
+                                    {
+                                        logger.Debug(string.Format("Plugin skipped, not enabled: {0}", plugin.DllFilePath));
+                                    }
+                                }
+                                else
+                                {
+                                    logger.Error(string.Format("Plugin {0} failed to load", plugin.DllFilePath));
+                                }
                             }
-                            else
+                            catch (Exception ex)
                             {
-                                logger.Debug(string.Format("Skipping plugin: {0}", plugin.DllFilePath));
+                                logger.Log<Exception>(LogLevel.Error, "Failed to initialize " + Path.GetFileNameWithoutExtension(pluginFile) + " engine.", ex);
                             }
                         }
-                        catch (Exception ex)
+                    }
+
+                    foreach (GrepPlugin plugin in plugins)
+                    {
+                        foreach (string extension in plugin.Extensions)
                         {
-                            failedEngines[Path.GetFileNameWithoutExtension(pluginFile)] = ex.Message;
-                            logger.Log<Exception>(LogLevel.Error, "Failed to initialize " + Path.GetFileNameWithoutExtension(pluginFile) + " engine.", ex);
+                            if (extension != null)
+                            {
+                                string fileExtension = extension.TrimStart('.');
+                                if (!string.IsNullOrWhiteSpace(fileExtension) && !fileTypeEngines.ContainsKey(fileExtension))
+                                {
+                                    fileTypeEngines.Add(fileExtension, plugin);
+                                }
+                            }
                         }
                     }
                 }
@@ -74,52 +123,148 @@ namespace dnGREP.Engines
 
             LoadPlugins();
 
-            string fileExtension = Path.GetExtension(fileName).ToLower();
-            if (fileExtension.Length > 1)
-                fileExtension = fileExtension.Substring(1);
+            string fileExtension = Path.GetExtension(fileName).ToLower().TrimStart('.');
 
-            if (!fileTypeEngines.ContainsKey(fileExtension))
+            IGrepEngine poolEngine = FetchFromPool(fileExtension);
+            if (poolEngine != null)
             {
-                foreach (GrepPlugin plugin in plugins)
-                {
-                    if (plugin.Extensions.Contains(fileExtension))
-                    {
-                        fileTypeEngines[fileExtension] = plugin;
-                    }
-                }
+                poolEngine.Initialize(param, filter);
+                return poolEngine;
             }
-            GrepEnginePlainText plainTextEngine = new GrepEnginePlainText();
-            plainTextEngine.Initialize(param, filter);
 
-            if (fileTypeEngines.ContainsKey(fileExtension) && fileTypeEngines[fileExtension].Enabled)
+            if (fileTypeEngines.ContainsKey(fileExtension))
             {
-                if (FrameworkVersionsAreCompatible(fileTypeEngines[fileExtension].Engine.FrameworkVersion, plainTextEngine.FrameworkVersion))
+                IGrepEngine engine = fileTypeEngines[fileExtension].CreateEngine();
+                if (engine != null && engine.Initialize(param, filter))
                 {
-                    if (fileTypeEngines[fileExtension].Engine.Initialize(param, filter))
-                    {
-                        logger.Debug(string.Format("Using plugin: {0} for extension {1}",
-                            fileTypeEngines[fileExtension].Engine.ToString(), fileExtension));
-                        return fileTypeEngines[fileExtension].Engine;
-                    }
-                    else
-                    {
-                        logger.Debug(string.Format("File type engines failed to initialize: {0}, using plainTextEngine", fileExtension));
-                        failedEngines[fileTypeEngines[fileExtension].Engine.GetType().Name] = "Failed to initialize the plugin. See error log for details.";
-                        return plainTextEngine;
-                    }
+                    loadedEngines.Add(engine);
+                    logger.Debug(string.Format("Using plugin: {0} for extension {1}", engine.ToString(), fileExtension));
+                    return engine;
                 }
                 else
                 {
-                    logger.Debug(string.Format("File type engines version mismatch for: {0}, using plainTextEngine", fileExtension));
-                    failedEngines[fileTypeEngines[fileExtension].Engine.GetType().Name] = "Plugin developed under outdated framework. Please update the plugin.";
-                    return plainTextEngine;
+                    logger.Debug(string.Format("File type engines failed to initialize: {0}, using plainTextEngine", fileExtension));
+                    failedEngines[engine.GetType().Name] = "Failed to initialize the plugin. See error log for details.";
+                    return GetPlainTextEngine(fileExtension, param, filter);
                 }
             }
             else
             {
                 logger.Debug(string.Format("File type engines has no key for: {0}, using plainTextEngine", fileExtension));
-                return plainTextEngine;
+                return GetPlainTextEngine(fileExtension, param, filter);
             }
+        }
+
+        public static IGrepEngine GetReplaceEngine(string fileName, GrepEngineInitParams param, FileFilter filter)
+        {
+            Debug.Assert(param != null);
+            Debug.Assert(filter != null);
+
+            LoadPlugins();
+
+            string fileExtension = Path.GetExtension(fileName).ToLower().TrimStart('.');
+
+            if (fileTypeEngines.ContainsKey(fileExtension) && !fileTypeEngines[fileExtension].IsSearchOnly)
+            {
+                IGrepEngine engine = fileTypeEngines[fileExtension].CreateEngine();
+                if (engine != null && engine.Initialize(param, filter))
+                {
+                    loadedEngines.Add(engine);
+                    return engine;
+                }
+                else
+                {
+                    failedEngines[engine.GetType().Name] = "Failed to initialize the plugin. See error log for details.";
+                    return GetPlainTextEngine(fileExtension, param, filter);
+                }
+            }
+            else
+                return GetPlainTextEngine(fileExtension, param, filter);
+        }
+
+        private static IGrepEngine GetPlainTextEngine(string fileExtension, GrepEngineInitParams param, FileFilter filter)
+        {
+            if (!poolKeys.ContainsKey(fileExtension))
+            {
+                poolKeys.Add(fileExtension, "GrepEnginePlainText");
+            }
+
+            IGrepEngine poolEngine = FetchFromPool(fileExtension);
+            if (poolEngine != null)
+            {
+                poolEngine.Initialize(param, filter);
+                return poolEngine;
+            }
+
+            IGrepEngine engine = new GrepEnginePlainText();
+            loadedEngines.Add(engine);
+            engine.Initialize(param, filter);
+            return engine;
+        }
+
+        private static IGrepEngine FetchFromPool(string fileExtension)
+        {
+            lock (lockObj)
+            {
+                IGrepEngine engine = null;
+                string poolKey;
+                if (poolKeys.TryGetValue(fileExtension, out poolKey))
+                {
+                    Queue<IGrepEngine> pooledEngines;
+                    if (GrepEngineFactory.pooledEngines.TryGetValue(poolKey, out pooledEngines))
+                    {
+                        if (pooledEngines.Count > 0)
+                        {
+                            engine = pooledEngines.Dequeue();
+                        }
+                    }
+                }
+                return engine;
+            }
+        }
+
+        public static void ReturnToPool(string fileName, IGrepEngine engine)
+        {
+            lock (lockObj)
+            {
+                string fileExtension = Path.GetExtension(fileName).ToLower().TrimStart('.');
+                string poolKey;
+                if (poolKeys.TryGetValue(fileExtension, out poolKey))
+                {
+                    Queue<IGrepEngine> pooledEngines;
+
+                    if (!GrepEngineFactory.pooledEngines.TryGetValue(poolKey, out pooledEngines))
+                    {
+                        pooledEngines = new Queue<IGrepEngine>();
+                        GrepEngineFactory.pooledEngines.Add(poolKey, pooledEngines);
+                    }
+
+                    pooledEngines.Enqueue(engine);
+                }
+            }
+        }
+
+        public static void UnloadEngines()
+        {
+            lock (lockObj)
+            {
+                pooledEngines.Clear();
+
+                foreach (IGrepEngine engine in loadedEngines)
+                {
+                    engine.Unload();
+                    var disposable = engine as IDisposable;
+                    if (disposable != null)
+                        disposable.Dispose();
+                }
+
+                loadedEngines.Clear();
+            }
+        }
+
+        public static Version FrameworkVersion
+        {
+            get { return Assembly.GetAssembly(typeof(IGrepEngine)).GetName().Version; }
         }
 
         /// <summary>
@@ -128,59 +273,6 @@ namespace dnGREP.Engines
         private static bool FrameworkVersionsAreCompatible(Version version1, Version version2)
         {
             return (version1.Major == version2.Major);
-        }
-
-        public static IGrepEngine GetReplaceEngine(string fileName, GrepEngineInitParams param, FileFilter filter)
-        {
-            LoadPlugins();
-
-            string fileExtension = Path.GetExtension(fileName);
-            if (fileExtension.Length > 1)
-                fileExtension = fileExtension.Substring(1);
-
-            if (!fileTypeEngines.ContainsKey(fileExtension))
-            {
-                foreach (GrepPlugin plugin in plugins)
-                {
-                    if (plugin.Extensions.Contains(fileExtension))
-                    {
-                        fileTypeEngines[fileExtension] = plugin;
-                    }
-                }
-            }
-            GrepEnginePlainText plainTextEngine = new GrepEnginePlainText();
-            plainTextEngine.Initialize(param, filter);
-
-            if (fileTypeEngines.ContainsKey(fileExtension) && fileTypeEngines[fileExtension].Enabled && !fileTypeEngines[fileExtension].Engine.IsSearchOnly)
-            {
-                if (FrameworkVersionsAreCompatible(fileTypeEngines[fileExtension].Engine.FrameworkVersion, plainTextEngine.FrameworkVersion))
-                {
-                    if (fileTypeEngines[fileExtension].Engine.Initialize(param, filter))
-                    {
-                        return fileTypeEngines[fileExtension].Engine;
-                    }
-                    else
-                    {
-                        failedEngines[fileTypeEngines[fileExtension].Engine.GetType().Name] = "Failed to initialize the plugin. See error log for details.";
-                        return plainTextEngine;
-                    }
-                }
-                else
-                {
-                    failedEngines[fileTypeEngines[fileExtension].Engine.GetType().Name] = "Plugin developed under outdated framework. Please update the plugin.";
-                    return plainTextEngine;
-                }
-            }
-            else
-                return plainTextEngine;
-        }
-
-        public static void UnloadEngines()
-        {
-            foreach (string key in fileTypeEngines.Keys)
-            {
-                fileTypeEngines[key].Engine.Unload();
-            }
         }
 
         public static string GetListOfFailedEngines()

--- a/dnGREP.PdfEngine/GrepEnginePdf.cs
+++ b/dnGREP.PdfEngine/GrepEnginePdf.cs
@@ -79,6 +79,8 @@ namespace dnGREP.Engines.Pdf
                     }
                 }
 
+                GrepEngineFactory.ReturnToPool(tempFile, engine);
+
                 return results;
             }
             catch (Exception ex)

--- a/dnGREP.Setup/Product.wxs
+++ b/dnGREP.Setup/Product.wxs
@@ -6,7 +6,7 @@
            Name="dnGREP $(var.MajorVersion).$(var.MinorVersion).$(var.BuildVersion) ($(var.Platform))"
            Language="1033"
            Version="$(var.ProductVersion)"
-           Manufacturer="dnGrep Developers"
+           Manufacturer="dnGrep Community Contributors"
            UpgradeCode="4CF55558-B642-482E-9FBF-06EA5AEC8276">
     <Package InstallerVersion="200" Compressed="yes" />
 

--- a/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
+++ b/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
@@ -141,7 +141,14 @@ namespace dnGREP.WPF
 
         public void AddRange(List<GrepSearchResult> list)
         {
-            foreach (var l in list) this.Add(new FormattedGrepResult(l, folderPath));
+            foreach (var l in list)
+                Add(new FormattedGrepResult(l, folderPath));
+        }
+
+        public void AddRange(IEnumerable<FormattedGrepResult> items)
+        {
+            foreach (var item in items)
+                Add(item);
         }
 
         private string folderPath = "";

--- a/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
@@ -250,6 +250,22 @@ namespace dnGREP.WPF
             }
         }
 
+
+        private bool searchParallel;
+        public bool SearchParallel
+        {
+            get { return searchParallel; }
+            set
+            {
+                if (value == searchParallel)
+                    return;
+
+                searchParallel = value;
+
+                base.OnPropertyChanged(() => SearchParallel);
+            }
+        }
+
         private SearchType typeOfSearch;
         public SearchType TypeOfSearch
         {
@@ -1316,6 +1332,7 @@ namespace dnGREP.WPF
             IncludeHidden = settings.Get<bool>(GrepSettings.Key.IncludeHidden);
             IncludeBinary = settings.Get<bool>(GrepSettings.Key.IncludeBinary);
             IncludeArchive = settings.Get<bool>(GrepSettings.Key.IncludeArchive) && Utils.ArchiveExtensions.Count > 0;
+            SearchParallel = settings.Get<bool>(GrepSettings.Key.SearchParallel);
             IncludeSubfolder = settings.Get<bool>(GrepSettings.Key.IncludeSubfolder);
             TypeOfSearch = settings.Get<SearchType>(GrepSettings.Key.TypeOfSearch);
             TypeOfFileSearch = settings.Get<FileSearchType>(GrepSettings.Key.TypeOfFileSearch);
@@ -1349,6 +1366,7 @@ namespace dnGREP.WPF
             settings.Set<bool>(GrepSettings.Key.IncludeHidden, IncludeHidden);
             settings.Set<bool>(GrepSettings.Key.IncludeBinary, IncludeBinary);
             settings.Set<bool>(GrepSettings.Key.IncludeArchive, IncludeArchive);
+            settings.Set<bool>(GrepSettings.Key.SearchParallel, SearchParallel);
             settings.Set<bool>(GrepSettings.Key.IncludeSubfolder, IncludeSubfolder);
             settings.Set<SearchType>(GrepSettings.Key.TypeOfSearch, TypeOfSearch);
             settings.Set<int>(GrepSettings.Key.CodePage, CodePage);

--- a/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
@@ -18,9 +18,8 @@ namespace dnGREP.WPF
 
         public BaseMainViewModel()
         {
-            searchResults = new ObservableGrepSearchResults();
-            this.RequestClose += MainViewModel_RequestClose;
-            this.PropertyChanged += MainViewModel_PropertyChanged;
+            RequestClose += MainViewModel_RequestClose;
+            PropertyChanged += MainViewModel_PropertyChanged;
 
             CurrentGrepOperation = GrepOperation.None;
             IsCaseSensitiveEnabled = true;

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -486,7 +486,12 @@ namespace dnGREP.WPF
 
                 FormattedGrepResult result = selectedNode.Parent;
                 OpenFileArgs fileArg = new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs));
-                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, GrepEngineInitParams.Default, new FileFilter()).OpenFile(fileArg);
+                IGrepEngine engine = GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, GrepEngineInitParams.Default, new FileFilter());
+                if (engine != null)
+                {
+                    engine.OpenFile(fileArg);
+                    GrepEngineFactory.ReturnToPool(result.GrepResult.FileNameReal, engine);
+                }
                 if (fileArg.UseBaseEngine)
                     Utils.OpenFile(new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs)));
             }
@@ -507,7 +512,12 @@ namespace dnGREP.WPF
                 // Line was selected
                 int lineNumber = 0;
                 OpenFileArgs fileArg = new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs));
-                dnGREP.Engines.GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, GrepEngineInitParams.Default, new FileFilter()).OpenFile(fileArg);
+                IGrepEngine engine = GrepEngineFactory.GetSearchEngine(result.GrepResult.FileNameReal, GrepEngineInitParams.Default, new FileFilter());
+                if (engine != null)
+                {
+                    engine.OpenFile(fileArg);
+                    GrepEngineFactory.ReturnToPool(result.GrepResult.FileNameReal, engine);
+                }
                 if (fileArg.UseBaseEngine)
                     Utils.OpenFile(new OpenFileArgs(result.GrepResult, result.GrepResult.Pattern, lineNumber, useCustomEditor, settings.Get<string>(GrepSettings.Key.CustomEditor), settings.Get<string>(GrepSettings.Key.CustomEditorArgs)));
             }

--- a/dnGREP.WPF/ViewModels/OptionsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/OptionsViewModel.cs
@@ -45,6 +45,7 @@ namespace dnGREP.WPF
                 AllowSearchWithEmptyPattern != settings.Get<bool>(GrepSettings.Key.AllowSearchingForFileNamePattern) ||
                 AutoExpandSearchTree != settings.Get<bool>(GrepSettings.Key.ExpandResults) ||
                 ShowVerboseMatchCount != settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount) ||
+                MatchTimeout != settings.Get<double>(GrepSettings.Key.MatchTimeout) ||
                 MatchThreshold != settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold) ||
                 MaxSearchBookmarks != settings.Get<int>(GrepSettings.Key.MaxSearchBookmarks) ||
                 MaxPathBookmarks != settings.Get<int>(GrepSettings.Key.MaxPathBookmarks) ||
@@ -312,6 +313,21 @@ namespace dnGREP.WPF
             }
         }
 
+        private double matchTimeout;
+        public double MatchTimeout
+        {
+            get { return matchTimeout; }
+            set
+            {
+                if (value == matchTimeout)
+                    return;
+
+                matchTimeout = value;
+
+                base.OnPropertyChanged(() => MatchTimeout);
+            }
+        }
+
         private double matchThreshold;
         public double MatchThreshold
         {
@@ -507,6 +523,7 @@ namespace dnGREP.WPF
             AllowSearchWithEmptyPattern = settings.Get<bool>(GrepSettings.Key.AllowSearchingForFileNamePattern);
             AutoExpandSearchTree = settings.Get<bool>(GrepSettings.Key.ExpandResults);
             showVerboseMatchCount = settings.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount);
+            MatchTimeout = settings.Get<double>(GrepSettings.Key.MatchTimeout);
             MatchThreshold = settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold);
             ShowLinesInContext = settings.Get<bool>(GrepSettings.Key.ShowLinesInContext);
             ContextLinesBefore = settings.Get<int>(GrepSettings.Key.ContextLinesBefore);
@@ -552,6 +569,7 @@ namespace dnGREP.WPF
             settings.Set<bool>(GrepSettings.Key.AllowSearchingForFileNamePattern, AllowSearchWithEmptyPattern);
             settings.Set<bool>(GrepSettings.Key.ExpandResults, AutoExpandSearchTree);
             settings.Set<bool>(GrepSettings.Key.ShowVerboseMatchCount, showVerboseMatchCount);
+            settings.Set<double>(GrepSettings.Key.MatchTimeout, MatchTimeout);
             settings.Set<double>(GrepSettings.Key.FuzzyMatchThreshold, MatchThreshold);
             settings.Set<bool>(GrepSettings.Key.ShowLinesInContext, ShowLinesInContext);
             settings.Set<int>(GrepSettings.Key.ContextLinesBefore, ContextLinesBefore);
@@ -772,6 +790,11 @@ namespace dnGREP.WPF
                 {
                     if (MatchThreshold < 0 || MatchThreshold > 1.0)
                         error = "Error: Match threshold should be a number between 0 and 1.0";
+                }
+                else if (IsProperty(() => MatchTimeout, propertyName))
+                {
+                    if (MatchTimeout <= 0 || MatchTimeout > 60 * 60)
+                        error = "Error: Match Timeout should be a number 0 and 3600";
                 }
                 // Dirty the commands registered with CommandManager,
                 // such as our Save command, so that they are queried

--- a/dnGREP.WPF/ViewModels/TestPatternViewModel.cs
+++ b/dnGREP.WPF/ViewModels/TestPatternViewModel.cs
@@ -110,7 +110,8 @@ namespace dnGREP.WPF
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter),
                 GrepSettings.Instance.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
-                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)),
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount),
+                false),
                 new FileFilter());
             List<GrepSearchResult> results = new List<GrepSearchResult>();
             GrepSearchOption searchOptions = GrepSearchOption.None;
@@ -176,7 +177,8 @@ namespace dnGREP.WPF
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter),
                 GrepSettings.Instance.Get<double>(GrepSettings.Key.FuzzyMatchThreshold),
-                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount)),
+                GrepSettings.Instance.Get<bool>(GrepSettings.Key.ShowVerboseMatchCount),
+                false),
                 new FileFilter());
             List<GrepSearchResult> results = new List<GrepSearchResult>();
 

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -205,7 +205,7 @@
                                                          ToolTip="e.g. file??.*" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <CheckBox Grid.Row="1" IsChecked="{Binding SearchParallel}" Margin="3,0,24,3" Content="Search Paralle_l" TabIndex="42" ToolTip="Search files in multiple threads - results will not be ordered" />
+                                    <CheckBox Grid.Row="1" IsChecked="{Binding SearchParallel}" Margin="3,0,24,3" Content="Search Paralle_l" TabIndex="42" ToolTip="Search files in multiple threads" />
                                     <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="3">
                                         <TextBlock VerticalAlignment="Center" Margin="3,0,3,3" Text="Encoding:" HorizontalAlignment="Left" />
                                         <ComboBox Width="224" Name="cbEncoding" TabIndex="43" Margin="3,0,3,3"
@@ -328,10 +328,12 @@
                     <CheckBox Content="Stop after first match" IsChecked="{Binding StopAfterFirstMatch}" VerticalAlignment="Center" Margin="3,0" TabIndex="82" VerticalContentAlignment="Center"/>
                     <Button Content="_Search" Width="64" Margin="3" IsDefault="True" Command="{Binding SearchCommand}" TabIndex="83" Height="24"/>
                     <Button Content="Replace" Width="64" Margin="3" Command="{Binding ReplaceCommand}" TabIndex="84" Height="24"/>
+                    <Button Content="Sort" Width="64" Margin="3" Command="{Binding SortCommand}" TabIndex="85" Height="24"
+                            Visibility="{Binding SearchParallel, Converter={StaticResource BoolToVisibilityConverter}}"/>
                     <Button Content=">>" Width="32" Margin="3" Click="btnOtherActions_Click" 
-                            ContextMenuService.Placement="Bottom" IsEnabled="{Binding CanSearchInResults}" TabIndex="85" Height="24">
+                            ContextMenuService.Placement="Bottom" IsEnabled="{Binding CanSearchInResults}" TabIndex="86" Height="24">
                         <Button.ContextMenu>
-                            <ContextMenu x:Name="advanceContextMenu">f
+                            <ContextMenu x:Name="advanceContextMenu">
                                 <MenuItem Header="Copy files..." Command="{Binding CopyFilesCommand}"/>
                                 <MenuItem Header="Move files..." Command="{Binding MoveFilesCommand}"/>
                                 <MenuItem Header="Delete files..." Command="{Binding DeleteFilesCommand}"/>
@@ -342,7 +344,7 @@
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>
-                    <Button Content="_Cancel" Width="64" Margin="3,3,8,3" Command="{Binding CancelCommand}" TabIndex="86" Height="24"/>
+                    <Button Content="_Cancel" Width="64" Margin="3,3,8,3" Command="{Binding CancelCommand}" TabIndex="87" Height="24"/>
                 </WrapPanel>
             </Grid>
             <Controls:ResultsTree DataContext="{Binding SearchResults}" TabIndex="90"/>

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -189,6 +189,7 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
@@ -204,19 +205,26 @@
                                                          ToolTip="e.g. file??.*" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="3">
+                                    <CheckBox Grid.Row="1" IsChecked="{Binding SearchParallel}" Margin="3,0,24,3" Content="Search Paralle_l" TabIndex="42" ToolTip="Search files in multiple threads - results will not be ordered" />
+                                    <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Center" Margin="3">
                                         <TextBlock VerticalAlignment="Center" Margin="3,0,3,3" Text="Encoding:" HorizontalAlignment="Left" />
-                                        <ComboBox Width="224" Name="cbEncoding" TabIndex="42" Margin="3,0,3,3"
+                                        <ComboBox Width="224" Name="cbEncoding" TabIndex="43" Margin="3,0,3,3"
                                               DisplayMemberPath="Key" SelectedValuePath="Value" ItemsSource="{Binding Path=Encodings}"
-                                              VerticalAlignment="Center" SelectedValue="{Binding Path=CodePage}" Initialized="cbEncoding_Initialized" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24" />
+                                              VerticalAlignment="Center" SelectedValue="{Binding Path=CodePage}" Initialized="cbEncoding_Initialized" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24">
+                                            <ComboBox.ItemContainerStyle>
+                                                <Style TargetType="{x:Type ComboBoxItem}">
+                                                    <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                                                </Style>
+                                            </ComboBox.ItemContainerStyle>
+                                        </ComboBox>
                                     </StackPanel>
-                                    <UniformGrid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="4,3,3,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
-                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="43" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="44" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="44" Content="_Multiline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
-                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="45" Content="_Dot as newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                    <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="4,3,3,3" Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                                        <CheckBox Grid.Row="0" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding CaseSensitive}" IsEnabled="{Binding IsCaseSensitiveEnabled}" TabIndex="44" Content="C_ase sensitive" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="0" Margin="3,0,3,3" IsChecked="{Binding WholeWord}" IsEnabled="{Binding IsWholeWordEnabled}" TabIndex="45" Content="_Whole word" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="0" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Multiline}" IsEnabled="{Binding IsMultilineEnabled}" TabIndex="46" Content="_Multiline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Row="1" Grid.Column="1" Margin="3,0,3,3" IsChecked="{Binding Singleline}" IsEnabled="{Binding IsSinglelineEnabled}" TabIndex="47" Content="_Dot as newline" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
                                     </UniformGrid>
-                                    <Button Content="Reset Options" Margin="3,0,3,3" Command="{Binding ResetOptionsCommand}" TabIndex="46" Height="24" Grid.Row="3" Width="98" Grid.Column="1" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
+                                    <Button Grid.Row="4" Grid.Column="1" Content="Reset Options" Margin="3,0,3,3" Command="{Binding ResetOptionsCommand}" TabIndex="48" Height="24" Width="98" VerticalAlignment="Center" HorizontalContentAlignment="Center" HorizontalAlignment="Right" />
                                 </Grid>
                             </WrapPanel>
                         </GroupBox>

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -145,20 +145,31 @@
                         <RowDefinition SharedSizeGroup="xxx"/>
                     </Grid.RowDefinitions>
                     <StackPanel Grid.Row="0">
-                        <GroupBox Header="Phonetic search">
+                        <GroupBox Header="Regex Search">
                             <WrapPanel>
                                 <WrapPanel.Resources>
                                     <DataTemplate DataType="{x:Type ValidationError}">
-                                        <TextBlock
-                                      Foreground="Red"
-                                      HorizontalAlignment="Right"
-                                      Text="{Binding Path=ErrorContent}" 
-                                      />
+                                        <TextBlock Foreground="Red" HorizontalAlignment="Right" Text="{Binding Path=ErrorContent}" />
+                                    </DataTemplate>
+                                </WrapPanel.Resources>
+                                <Label>Match timeout</Label>
+                                <TextBox Name="tbMatchTimeout" Width="48" Text="{Binding Path=MatchTimeout, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
+                                     Validation.ErrorTemplate="{x:Null}" Height="24" VerticalContentAlignment="Center"/>
+                                <Label>seconds</Label>
+                                <TextBlock TextWrapping="Wrap">The match timeout limits how long the regular expression engine will attempt to resolve a regular expression before it times out. This prevents processing expressions and input strings that require excessive backtracking.</TextBlock>
+                                <ContentPresenter Content="{Binding ElementName=tbMatchTimeout, Path=(Validation.Errors).CurrentItem}"/>
+                            </WrapPanel>
+                        </GroupBox>
+                        <GroupBox Header="Phonetic Search" Margin="0,12,0,0">
+                            <WrapPanel>
+                                <WrapPanel.Resources>
+                                    <DataTemplate DataType="{x:Type ValidationError}">
+                                        <TextBlock Foreground="Red" HorizontalAlignment="Right" Text="{Binding Path=ErrorContent}" />
                                     </DataTemplate>
                                 </WrapPanel.Resources>
                                 <Label>Match threshold (from 0 to 1.0)</Label>
                                 <TextBox Name="tbFuzzyMatchThreshold" Width="48" Text="{Binding Path=MatchThreshold, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
-                                     Validation.ErrorTemplate="{x:Null}" Height="24" VerticalContentAlignment="Center" VerticalAlignment="Center"/>
+                                     Validation.ErrorTemplate="{x:Null}" Height="24" VerticalContentAlignment="Center"/>
                                 <Label>0 - match everything; 1.0 - exact match</Label>
                                 <ContentPresenter Content="{Binding ElementName=tbFuzzyMatchThreshold, Path=(Validation.Errors).CurrentItem}"/>
                             </WrapPanel>


### PR DESCRIPTION
#284 fixes for find file performance issues - summary of changes:
Stop converting asterisk patterns to regular expressions, and use the asterisk pattern to filter files while enumerating files.
Added new SafeDirectory class for enumerating directories and files, and handle access exceptions gracefully.
Added parallel processing while searching in files.  This is user option on the main options panel.
Rework the GrepEngineFactory and GrepPlugin classes to be thread-safe and pool grep engines.