### PR TITLE
Mods to Preview Window

### DIFF
--- a/dnGREP.Common.UI/Extensions.cs
+++ b/dnGREP.Common.UI/Extensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Interop;
 
 namespace dnGREP.Common.UI
 {
@@ -46,6 +49,28 @@ namespace dnGREP.Common.UI
             var loc = window.PointToScreen(new System.Windows.Point(0, 0));
 
             return new RectangleF((float)loc.X, (float)loc.Y, (float)window.ActualWidth, (float)window.ActualHeight);
+        }
+
+        public static void BringToFront(this Window window)
+        {
+            IntPtr hWnd = new WindowInteropHelper(window).Handle;
+            NativeMethods.BringToFront(hWnd);
+        }
+
+        internal class NativeMethods
+        {
+            const int SWP_NOMOVE = 0x0002;
+            const int SWP_NOSIZE = 0x0001;
+            const int SWP_SHOWWINDOW = 0x0040;
+            const int SWP_NOACTIVATE = 0x0010;
+
+            [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
+            public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int Y, int cx, int cy, int wFlags);
+
+            public static void BringToFront(IntPtr hWnd)
+            {
+                SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOACTIVATE);
+            }
         }
     }
 }

--- a/dnGREP.Engines/GrepEngineFactory.cs
+++ b/dnGREP.Engines/GrepEngineFactory.cs
@@ -252,10 +252,13 @@ namespace dnGREP.Engines
 
                 foreach (IGrepEngine engine in loadedEngines)
                 {
-                    engine.Unload();
-                    var disposable = engine as IDisposable;
-                    if (disposable != null)
-                        disposable.Dispose();
+                    if (engine != null)
+                    {
+                        engine.Unload();
+                        var disposable = engine as IDisposable;
+                        if (disposable != null)
+                            disposable.Dispose();
+                    }
                 }
 
                 loadedEngines.Clear();

--- a/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
@@ -1388,6 +1388,8 @@ namespace dnGREP.WPF
             settings.SetNullableDateTime(GrepSettings.Key.EndDate, EndDate);
             settings.Set<int>(GrepSettings.Key.HoursFrom, HoursFrom);
             settings.Set<int>(GrepSettings.Key.HoursTo, HoursTo);
+
+            settings.Save();
         }
 
         #endregion
@@ -1403,6 +1405,12 @@ namespace dnGREP.WPF
         {
             Utils.CancelSearch = true;
             SaveSettings();
+            CloseChildWindows();
+        }
+
+        protected virtual void CloseChildWindows()
+        {
+            // do nothing in base class
         }
 
         #endregion

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -459,21 +459,23 @@ namespace dnGREP.WPF
             }
         }
 
-        public override void LoadSettings()
-        {
-            base.LoadSettings();
-        }
-
         public override void SaveSettings()
         {
             copyBookmarksToSettings();
-            base.SaveSettings();
-            settings.Save();
             if (preview != null)
             {
-                settings.Set<System.Drawing.Rectangle>(GrepSettings.Key.PreviewWindowSize, preview.GetBounds());
+                settings.Set<Rectangle>(GrepSettings.Key.PreviewWindowSize, preview.GetBounds());
+                preview.SaveSettings();
+            }
+
+            base.SaveSettings();
+        }
+
+        protected override void CloseChildWindows()
+        {
+            if (preview != null)
+            {
                 preview.ForceClose();
-                preview = null;
             }
         }
 
@@ -545,25 +547,19 @@ namespace dnGREP.WPF
         {
             if (PreviewFileContent)
             {
-                previewFile(formattedGrepResult.GrepResult.FileNameReal, formattedGrepResult.GrepResult, 0, parentWindow);
+                int lineNumber = 0;
+                if (formattedGrepResult.GrepResult != null && formattedGrepResult.GrepResult.Matches.Count > 0)
+                    lineNumber = formattedGrepResult.GrepResult.Matches[0].LineNumber;
+
+                previewFile(formattedGrepResult.GrepResult.FileNameReal, formattedGrepResult.GrepResult, lineNumber, parentWindow);
             }
         }
 
-        public void ActivatePreviewWindow()
+        public void ChangePreviewWindowState(WindowState state)
         {
             if (preview != null && preview.IsVisible)
             {
-                preview.Topmost = true;  // important
-                preview.Topmost = false; // important
-                preview.Focus();         // important
-            }
-        }
-
-        public void ChangePreviewWindowState(System.Windows.WindowState state)
-        {
-            if (preview != null && preview.IsVisible)
-            {
-                if (state != System.Windows.WindowState.Maximized)
+                if (state != WindowState.Maximized)
                     preview.WindowState = state;
             }
         }
@@ -1613,7 +1609,11 @@ namespace dnGREP.WPF
                 previewModel.LineNumber = line;
                 previewModel.Encoding = result.Encoding;
                 previewModel.FilePath = filePath;
+
+                if (preview.WindowState == WindowState.Minimized)
+                    preview.WindowState = WindowState.Normal;
                 preview.Show();
+                preview.BringToFront();
             }
         }
         #endregion

--- a/dnGREP.WPF/ViewModels/PreviewViewModel.cs
+++ b/dnGREP.WPF/ViewModels/PreviewViewModel.cs
@@ -163,8 +163,8 @@ namespace dnGREP.WPF
                     else
                         CurrentSyntax = "None";
 
-                    // Do not preview files over 1MB or binary
-                    if (fileInfo.Length > 1024000 ||
+                    // Do not preview files over 4MB or binary
+                    if (fileInfo.Length > 4096000 ||
                         Utils.IsBinary(FilePath))
                     {
                         IsLargeOrBinary = System.Windows.Visibility.Visible;

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         Title="{Binding WindowTitle}" MinWidth="500" MinHeight="485" WindowState="Normal"
         Icon="/dnGREP;component/nGREP.ico" 
-        Closing="MainForm_Closing" Loaded="Window_Loaded" Activated="Window_Activated" StateChanged="Window_StateChanged"
+        Closing="MainForm_Closing" Loaded="Window_Loaded" StateChanged="Window_StateChanged"
         SnapsToDevicePixels="True" ResizeMode="CanResizeWithGrip" AllowDrop="False"
         my:DiginesisHelpProvider.HelpKeyword="Search-Window" my:DiginesisHelpProvider.HelpNavigator="Topic" my:DiginesisHelpProvider.ShowHelp="True" 
         WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}" d:DesignWidth="795">

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -84,7 +84,8 @@ namespace dnGREP.WPF
             var textBox = (tbSearchFor.Template.FindName("PART_EditableTextBox", tbSearchFor) as TextBox);
             if (textBox != null && !tbSearchFor.IsDropDownOpen)
             {
-                Application.Current.Dispatcher.BeginInvoke(new Action(() => {
+                Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                {
                     textBox.SelectAll();
                     textBox.Focus();
                 }));
@@ -160,11 +161,6 @@ namespace dnGREP.WPF
             {
                 e.CancelCommand();
             }
-        }
-
-        private void Window_Activated(object sender, EventArgs e)
-        {
-            inputData.ActivatePreviewWindow();
         }
 
         private void Window_StateChanged(object sender, EventArgs e)

--- a/dnGREP.WPF/Views/PreviewView.xaml
+++ b/dnGREP.WPF/Views/PreviewView.xaml
@@ -2,7 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ae="http://icsharpcode.net/sharpdevelop/avalonedit"
-        Title="Preview" Height="415" Width="593" WindowStyle="ToolWindow" Closing="Window_Closing" ShowInTaskbar="False">
+        Title="Preview" Height="415" Width="593" 
+        Icon="/dnGREP;component/nGREP.ico" 
+        Closing="Window_Closing">
+    
     <DockPanel>
         <Grid DockPanel.Dock="Top" Background="{Binding ElementName=statusBar, Path=Background}" Name="previewPanel" Visibility="{Binding Path=IsLargeOrBinary}">
             <Grid.ColumnDefinitions>

--- a/dnGREP.WPF/Views/PreviewView.xaml.cs
+++ b/dnGREP.WPF/Views/PreviewView.xaml.cs
@@ -102,11 +102,15 @@ namespace dnGREP.WPF
             this.inputData.FilePath = null;
         }
 
+        internal void SaveSettings()
+        {
+            GrepSettings.Instance.Set<bool?>(GrepSettings.Key.PreviewWindowWrap, cbWrapText.IsChecked);
+            GrepSettings.Instance.Set<int>(GrepSettings.Key.PreviewWindowFont, (int)zoomSlider.Value);
+        }
+
         public void ForceClose()
         {
             forceClose = true;
-            GrepSettings.Instance.Set<bool?>(GrepSettings.Key.PreviewWindowWrap, cbWrapText.IsChecked);
-            GrepSettings.Instance.Set<int>(GrepSettings.Key.PreviewWindowFont, (int)zoomSlider.Value);
 
             if (inputData != null)
                 inputData.ShowPreview -= inputData_ShowPreview;
@@ -158,6 +162,7 @@ namespace dnGREP.WPF
             this.Title = string.Format("Previewing \"{0}\"", inputData.FilePath);
             textEditor.Load(inputData.FilePath);
             inputData.IsLargeOrBinary = System.Windows.Visibility.Collapsed;
+            textEditor.ScrollTo(inputData.LineNumber, 0);
         }
     }
 }


### PR DESCRIPTION
Select first match in file (#294)
Remove main window activation handler, and replace with call to SetWindowPos to bring preview window to front when a new file or line is selected in the main window.
Increase file size check for previewing files (#293)
Keep preview window open when the options or test window opens (#250)
Add null value check when removing grep engines.