### PR TITLE
Preview window should show/hide with main window #323

### DIFF
--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -562,6 +562,17 @@ namespace dnGREP.WPF
             }
         }
 
+        public void ChangePreviewWindowActivation(bool activate)
+        {
+            if (this.preview != null && this.preview.IsVisible)
+            {
+                if (activate && !this.preview.IsActive)
+                {
+                    this.preview.Activate();
+                }
+            }
+        }
+
         public void ChangePreviewWindowState(WindowState state)
         {
             if (preview != null && preview.IsVisible)
@@ -1717,7 +1728,6 @@ namespace dnGREP.WPF
                 {
                     preview = new PreviewView();
                     preview.DataContext = previewModel;
-                    preview.Owner = ParentWindow;
                     Rectangle bounds = settings.Get<Rectangle>(GrepSettings.Key.PreviewWindowSize);
                     if (bounds.Left == 0 && bounds.Right == 0)
                     {

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -1717,6 +1717,7 @@ namespace dnGREP.WPF
                 {
                     preview = new PreviewView();
                     preview.DataContext = previewModel;
+                    preview.Owner = ParentWindow;
                     Rectangle bounds = settings.Get<Rectangle>(GrepSettings.Key.PreviewWindowSize);
                     if (bounds.Left == 0 && bounds.Right == 0)
                     {

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         Title="{Binding WindowTitle}" MinWidth="500" MinHeight="485" WindowState="Normal"
         Icon="/dnGREP;component/nGREP.ico" 
-        Closing="MainForm_Closing" Loaded="Window_Loaded" StateChanged="Window_StateChanged"
+        Activated="Window_Activated" Closing="MainForm_Closing" Loaded="Window_Loaded" StateChanged="Window_StateChanged"
         SnapsToDevicePixels="True" ResizeMode="CanResizeWithGrip" AllowDrop="False"
         my:DiginesisHelpProvider.HelpKeyword="Search-Window" my:DiginesisHelpProvider.HelpNavigator="Topic" my:DiginesisHelpProvider.ShowHelp="True" 
         WindowStartupLocation="Manual" FocusManager.FocusedElement="{Binding ElementName=tbSearchFor}" d:DesignWidth="795">

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -163,6 +163,11 @@ namespace dnGREP.WPF
             }
         }
 
+        private void Window_Activated(object sender, EventArgs e)
+        {
+            this.inputData.ChangePreviewWindowActivation(true);
+        }
+
         private void Window_StateChanged(object sender, EventArgs e)
         {
             inputData.ChangePreviewWindowState(this.WindowState);


### PR DESCRIPTION
When I do window switching, I have two windows to bring to front instead of one. If I bring the main window to front, I wish the preview window would be brought to front.

I believe the fix is this:
MainViewModel.cs around line: 1720
preview.Owner = ParentWindow;