### PR TITLE
Add new brushes for window border to override the os chrome border

### DIFF
--- a/dnGREP.WPF/ThemedControls/FloatWindow.xaml
+++ b/dnGREP.WPF/ThemedControls/FloatWindow.xaml
@@ -124,8 +124,9 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate TargetType="df:FloatWindow">
-                    <!--  This border lets the active-window highlighting (colored border around window) show through from the OS WindowChrome  -->
-                    <Border x:Name="root" Padding="1" UseLayoutRounding="True">
+                    <Border x:Name="root" Padding="0"
+                            BorderBrush="{DynamicResource Window.Border.Inactive}"
+                            BorderThickness="1" UseLayoutRounding="True">
                         <DockPanel x:Name="innerRoot" Background="{TemplateBinding Background}">
                             <DockPanel x:Name="titleBar"
                                        Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(shell:WindowChrome.WindowChrome).CaptionHeight, Mode=OneWay}"
@@ -164,9 +165,11 @@
                     <ControlTemplate.Triggers>
                         <!--  Fix issue where WPF cuts off content edges when window is maximized  -->
                         <Trigger Property="WindowState" Value="Maximized">
-                            <Setter TargetName="root" Property="Padding" Value="{Binding Source={x:Static SystemParameters.WindowResizeBorderThickness}}" />
                             <Setter TargetName="innerRoot" Property="Margin" Value="{Binding Source={x:Static SystemParameters.WindowResizeBorderThickness}}" />
                             <Setter TargetName="PART_RestoreButton" Property="Style" Value="{StaticResource RestoreButtonStyle}" />
+                        </Trigger>
+                        <Trigger Property="IsActive" Value="true">
+                            <Setter TargetName="root" Property="BorderBrush" Value="{DynamicResource Window.Border.Active}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/dnGREP.WPF/ThemedControls/ThemedWindow.xaml
+++ b/dnGREP.WPF/ThemedControls/ThemedWindow.xaml
@@ -106,8 +106,9 @@
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:ThemedWindow">
-                    <!--  This border lets the active-window highlighting (colored border around window) show through from the OS WindowChrome  -->
-                    <Border x:Name="root" Padding="1" UseLayoutRounding="True">
+                    <Border x:Name="root" Padding="0"
+                            BorderBrush="{DynamicResource Window.Border.Inactive}"
+                            BorderThickness="1" UseLayoutRounding="True">
                         <DockPanel x:Name="innerRoot" Background="{TemplateBinding Background}">
                             <DockPanel x:Name="titleBar"
                                        Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(shell:WindowChrome.WindowChrome).CaptionHeight, Mode=OneWay}"
@@ -157,9 +158,11 @@
                     <ControlTemplate.Triggers>
                         <!--  Fix issue where WPF cuts off content edges when window is maximized  -->
                         <Trigger Property="WindowState" Value="Maximized">
-                            <Setter TargetName="root" Property="Padding" Value="{Binding Source={x:Static SystemParameters.WindowResizeBorderThickness}}" />
                             <Setter TargetName="innerRoot" Property="Margin" Value="{Binding Source={x:Static SystemParameters.WindowResizeBorderThickness}}" />
                             <Setter TargetName="PART_RestoreButton" Property="Style" Value="{StaticResource RestoreButtonStyle}" />
+                        </Trigger>
+                        <Trigger Property="IsActive" Value="true">
+                            <Setter TargetName="root" Property="BorderBrush" Value="{DynamicResource Window.Border.Active}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/dnGREP.WPF/Themes/DarkBrushes.xaml
+++ b/dnGREP.WPF/Themes/DarkBrushes.xaml
@@ -25,6 +25,8 @@
     <SolidColorBrush x:Key="Splitter.Background" po:Freeze="true" Color="#FF989898" />
 
     <!--  Window Caption  -->
+    <SolidColorBrush x:Key="Window.Border.Active" po:Freeze="true" Color="#FF1475A6" />
+    <SolidColorBrush x:Key="Window.Border.Inactive" po:Freeze="true" Color="#FF2C628B" />
     <SolidColorBrush x:Key="Caption.Background" po:Freeze="true" Color="#FF333333" />
     <SolidColorBrush x:Key="Caption.Foreground" po:Freeze="true" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="Caption.Dialog.Background" po:Freeze="true" Color="#FF666666" />

--- a/dnGREP.WPF/Themes/LightBrushes.xaml
+++ b/dnGREP.WPF/Themes/LightBrushes.xaml
@@ -25,6 +25,8 @@
     <SolidColorBrush x:Key="Splitter.Background" po:Freeze="true" Color="#FFC8C8C8" />
 
     <!--  Window Caption  -->
+    <SolidColorBrush x:Key="Window.Border.Active" po:Freeze="true" Color="#FF707070" />
+    <SolidColorBrush x:Key="Window.Border.Inactive" po:Freeze="true" Color="#FFAAAAAA" />
     <SolidColorBrush x:Key="Caption.Background" po:Freeze="true" Color="White" />
     <SolidColorBrush x:Key="Caption.Foreground" po:Freeze="true" Color="Black" />
     <SolidColorBrush x:Key="Caption.Dialog.Background" po:Freeze="true" Color="#FFFAFAFA" />

--- a/dnGREP.WPF/Themes/Sunset.xaml
+++ b/dnGREP.WPF/Themes/Sunset.xaml
@@ -25,6 +25,8 @@
     <SolidColorBrush x:Key="Splitter.Background" po:Freeze="true" Color="#FF989898" />
 
     <!--  Window Caption  -->
+    <SolidColorBrush x:Key="Window.Border.Active" po:Freeze="true" Color="#FFA64514" />
+    <SolidColorBrush x:Key="Window.Border.Inactive" po:Freeze="true" Color="#FF8B552C" />
     <SolidColorBrush x:Key="Caption.Background" po:Freeze="true" Color="#FF333333" />
     <SolidColorBrush x:Key="Caption.Foreground" po:Freeze="true" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="Caption.Dialog.Background" po:Freeze="true" Color="#FF666666" />


### PR DESCRIPTION
In Windows 10 version 1903, letting the os chrome window border bleed through can give a white border on a dark themed window.  