### PR TITLE
Allow preview of files already open for write

### DIFF
--- a/dnGREP.WPF/Views/PreviewControl.xaml.cs
+++ b/dnGREP.WPF/Views/PreviewControl.xaml.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using dnGREP.Common;
+
+using File = Alphaleonis.Win32.Filesystem.File;
 
 namespace dnGREP.WPF
 {
@@ -61,8 +64,10 @@ namespace dnGREP.WPF
                     {
                         if (!string.IsNullOrWhiteSpace(ViewModel.FilePath))
                         {
-                            //Title = string.Format("Previewing \"{0}\"", ViewModel.DisplayFileName);
-                            textEditor.Load(ViewModel.FilePath);
+                            using (FileStream stream = File.Open(ViewModel.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                            {
+                                textEditor.Load(stream);
+                            }
                             if (textEditor.IsLoaded)
                             {
                                 textEditor.ScrollTo(ViewModel.LineNumber, 0);

--- a/dnGREP.WPF/Views/ReplaceWindow.xaml.cs
+++ b/dnGREP.WPF/Views/ReplaceWindow.xaml.cs
@@ -162,6 +162,12 @@ namespace dnGREP.WPF
             catch (Exception ex)
             {
                 textEditor.Text = "Error opening the file: " + ex.Message;
+                // remove the highligher
+                for (int i = textEditor.TextArea.TextView.LineTransformers.Count - 1; i >= 0; i--)
+                {
+                    if (textEditor.TextArea.TextView.LineTransformers[i] is ReplaceViewHighlighter)
+                        textEditor.TextArea.TextView.LineTransformers.RemoveAt(i);
+                }
             }
 
             // recalculate the width of the line number margin


### PR DESCRIPTION
Do not open files for replace selection that are open for write, and remove the match highlight