### PR TITLE
workaround to issue#418 WindowChrome arithmatic overflow

### DIFF
--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -88,7 +88,10 @@ namespace dnGREP.WPF
         protected override void OnSourceInitialized(EventArgs e)
         {
             if (isVisible)
+            {
                 base.OnSourceInitialized(e);
+                ((HwndSource)PresentationSource.FromVisual(this)).AddHook(HookProc);
+            }
 
             if (!isVisible)
             {
@@ -99,6 +102,23 @@ namespace dnGREP.WPF
                     Visibility = Visibility.Hidden;
                 }
             }
+        }
+
+        private IntPtr HookProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == 0x0084 /*WM_NCHITTEST*/ )
+            {
+                // This prevents a crash in WindowChromeWorker._HandleNCHitTest
+                try
+                {
+                    lParam.ToInt32();
+                }
+                catch (OverflowException)
+                {
+                    handled = true;
+                }
+            }
+            return IntPtr.Zero;
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
I copied the workaround code made by Dave from [https://developercommunity.visualstudio.com/content/problem/167357/overflow-exception-in-windowchrome.html](url)

It solves the issue. Actually, as the other thread mentioned, it is not only the Logitech mouse but other mouses as well. My mouse is a Microsoft mouse. 

Base on my testing, it is due to the positioning of two monitors. 
If the main monitor is above the second monitor, no issues. 
If the main monitor is below the second monitor, the issue happens.