### PR TITLE
move capture of before context lines

### DIFF
--- a/Tests/GrepCoreTest.cs
+++ b/Tests/GrepCoreTest.cs
@@ -370,7 +370,8 @@ namespace Tests
             List<GrepSearchResult> results = core.Search(Directory.GetFiles(Path.Combine(destFolder, "TestCase4"), "app.config"), SearchType.XPath,
                 "//setting", GrepSearchOption.CaseSensitive, -1);
             Assert.Single(results);
-            Assert.Equal(84, results[0].SearchResults.Count);
+            var lines = results[0].GetLinesWithContext(0, 0);
+            Assert.Equal(84, lines.Count);
         }
 
         [Theory]

--- a/Tests/UtilsTest.cs
+++ b/Tests/UtilsTest.cs
@@ -143,6 +143,25 @@ namespace Tests
             Assert.Equal(6, lines[2].LineNumber);
             Assert.Equal("loop", lines[2].LineText);
             Assert.True(lines[2].IsContext);
+
+            // test added for github issue 417: the 'before' context lines were missing
+            // from multiline regex match
+            bodyMatches = new List<GrepMatch>();
+            using (StringReader reader = new StringReader(test))
+            {
+                bodyMatches.Clear();
+                bodyMatches.Add(new GrepMatch(4, 15, 21));
+                lines = Utils.GetLinesEx(reader, bodyMatches, 2, 3);
+            }
+
+            Assert.Equal(5, lines.Count);
+            Assert.Equal(2, lines[0].LineNumber);
+            Assert.Equal(3, lines[1].LineNumber);
+            Assert.Equal("World", lines[1].LineText);
+            Assert.True(lines[1].IsContext);
+            Assert.Equal(4, lines[2].LineNumber);
+            Assert.Equal("My name is Denis", lines[2].LineText);
+            Assert.False(lines[2].IsContext);
         }
 
         [Fact]

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -1759,7 +1759,7 @@ namespace dnGREP.Common
         /// Retrieves lines with context based on matches
         /// </summary>
         /// <param name="body">Text</param>
-        /// <param name="bodyMatchesClone">List of matches with positions relative to entire text body</param>
+        /// <param name="bodyMatches">List of matches with positions relative to entire text body</param>
         /// <param name="beforeLines">Context line (before)</param>
         /// <param name="afterLines">Context line (after</param>
         /// <returns></returns>
@@ -1827,6 +1827,17 @@ namespace dnGREP.Common
                             startLine = lineNumber;
                             startIndex = bodyMatchesClone[0].StartLocation - currentIndex;
                             tempLinesTotalLength = 0;
+
+                            // Recording the before match context lines
+                            while (beforeQueue.Count > 0)
+                            {
+                                // If only 1 line - it is the same as matched line
+                                if (beforeQueue.Count == 1)
+                                    beforeQueue.Dequeue();
+                                else
+                                    contextLines.Add(new GrepLine(startLine - beforeQueue.Count + 1 + (lineNumber - startLine),
+                                        beforeQueue.Dequeue(), true, null));
+                            }
                         }
 
                         // Add line to queue
@@ -1847,16 +1858,7 @@ namespace dnGREP.Common
                                 lineNumbers.Add(i);
                                 string tempLine = lineQueue.Dequeue();
                                 lineStrings[i] = tempLine;
-                                // Recording context lines (before)
-                                while (beforeQueue.Count > 0)
-                                {
-                                    // If only 1 line - it is the same as matched line
-                                    if (beforeQueue.Count == 1)
-                                        beforeQueue.Dequeue();
-                                    else
-                                        contextLines.Add(new GrepLine(i - beforeQueue.Count + 1 + (lineNumber - startLine),
-                                            beforeQueue.Dequeue(), true, null));
-                                }
+
                                 string fileMatchId = bodyMatchesClone[0].FileMatchId;
                                 // First and only line
                                 if (i == startLine && i == lineNumber)


### PR DESCRIPTION
so they are not lost when processing a multiline match
add new unit test
fix broken unit test