### PR TITLE
Defer checking path until the search button is clicked.

### DIFF
--- a/dnGREP.Common/PathSearchText.cs
+++ b/dnGREP.Common/PathSearchText.cs
@@ -21,7 +21,6 @@ namespace dnGREP.Common
                     return;
 
                 baseFolder = null;
-                isValidBaseFolder = null;
                 isValidPath = null;
                 fileOrFolderPath = value;
             }
@@ -72,22 +71,6 @@ namespace dnGREP.Common
             }
         }
 
-        private bool? isValidBaseFolder;
-        /// <summary>
-        /// Gets a flag indicating the BaseFolder is valid
-        /// </summary>
-        public bool IsValidBaseFolder
-        {
-            get
-            {
-                if (!isValidBaseFolder.HasValue)
-                {
-                    isValidBaseFolder = Utils.IsPathValid(BaseFolder);
-                }
-                return isValidBaseFolder.Value;
-            }
-        }
-
         private bool? isValidPath;
         /// <summary>
         /// Gets a flag indicating the path or set of paths are valid
@@ -101,7 +84,8 @@ namespace dnGREP.Common
                     if (TypeOfFileSearch == FileSearchType.Everything)
                         isValidPath = !string.IsNullOrWhiteSpace(FileOrFolderPath);
                     else
-                        isValidPath = Utils.IsPathValid(fileOrFolderPath);
+                        isValidPath = !string.IsNullOrWhiteSpace(FileOrFolderPath) && 
+                            Utils.IsPathValid(fileOrFolderPath);
                 }
                 return isValidPath.Value;
             }

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -915,7 +915,7 @@ namespace dnGREP.Common
             if (!string.IsNullOrWhiteSpace(path))
             {
                 string parent = Path.GetDirectoryName(path);
-                if (Directory.Exists(parent))
+                if (!string.IsNullOrWhiteSpace(parent) && Directory.Exists(parent))
                 {
                     string pattern = Path.GetFileName(path);
                     if (pattern.Contains(Path.WildcardQuestion) || pattern.Contains(Path.WildcardStarMatchAll))

--- a/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
+++ b/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
@@ -190,7 +190,7 @@ namespace dnGREP.WPF
         {
             foreach (var l in list)
             {
-                var fmtResult = new FormattedGrepResult(l, folderPath)
+                var fmtResult = new FormattedGrepResult(l, FolderPath)
                 {
                     WrapText = WrapText
                 };
@@ -209,7 +209,7 @@ namespace dnGREP.WPF
         {
             foreach (var l in list)
             {
-                Add(new FormattedGrepResult(l, folderPath));
+                Add(new FormattedGrepResult(l, FolderPath));
             }
         }
 
@@ -219,12 +219,7 @@ namespace dnGREP.WPF
                 Add(item);
         }
 
-        private string folderPath = "";
-        public string FolderPath
-        {
-            get { return folderPath; }
-            set { folderPath = value; }
-        }
+        public string FolderPath { get; set; } = string.Empty;
 
         [DllImport("gdi32.dll")]
         static extern bool DeleteObject(IntPtr hObject);

--- a/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/BaseMainViewModel.cs
@@ -1418,9 +1418,6 @@ namespace dnGREP.WPF
                 }
             }
 
-            //searchResults
-            searchResults.FolderPath = PathSearchText.BaseFolder;
-
             //btnCancel
             if (name == "CurrentGrepOperation")
             {

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -1544,6 +1544,10 @@ namespace dnGREP.WPF
                         return;
                 }
 
+                // set base folder for results display
+                SearchResults.FolderPath = PathSearchText.BaseFolder;
+
+
                 if (SearchInResultsContent && CanSearchInResults)
                     CurrentGrepOperation = GrepOperation.SearchInResults;
                 else
@@ -2244,7 +2248,7 @@ namespace dnGREP.WPF
         {
             get
             {
-                return PathSearchText.IsValidBaseFolder && FilesFound && CurrentGrepOperation == GrepOperation.None &&
+                return FilesFound && CurrentGrepOperation == GrepOperation.None &&
                         !IsSaveInProgress && !string.IsNullOrEmpty(SearchFor) && SearchResults.GetWritableList().Count > 0 &&
                         // can only replace using the same parameters as was used for the search
                         !SearchParametersChanged &&


### PR DESCRIPTION
Moved set of search results folder path
Removed check for valid base folder in CanReplace