### PR TITLE
Cleanup English string resource

### DIFF
--- a/Tests/UtilsTest.cs
+++ b/Tests/UtilsTest.cs
@@ -704,7 +704,7 @@ namespace Tests
             Utils.SaveResultsAsCSV(results, destinationFolder + "\\test.csv");
             string[] stringLines = File.ReadAllLines(destinationFolder + "\\test.csv");
             Assert.Equal(177, stringLines.Length);
-            Assert.Equal("File name", stringLines[0].Split(',')[0].Trim());
+            Assert.Equal("File Name", stringLines[0].Split(',')[0].Trim());
             Assert.Equal("1", stringLines[1].Split(',')[1].Trim());
             Assert.Equal("\"\tstring returnedLine = Utils.GetLine(body", stringLines[2].Split(',')[2].Trim());
         }
@@ -723,7 +723,7 @@ namespace Tests
             Utils.SaveResultsAsCSV(results, longDestinationFolder + "\\test.csv");
             string[] stringLines = File.ReadAllLines(longDestinationFolder + "\\test.csv");
             Assert.Equal(177, stringLines.Length);
-            Assert.Equal("File name", stringLines[0].Split(',')[0].Trim());
+            Assert.Equal("File Name", stringLines[0].Split(',')[0].Trim());
             Assert.Equal("1", stringLines[1].Split(',')[1].Trim());
             Assert.Equal("\"\tstring returnedLine = Utils.GetLine(body", stringLines[2].Split(',')[2].Trim());
         }

--- a/Tests/UtilsTest.cs
+++ b/Tests/UtilsTest.cs
@@ -704,7 +704,7 @@ namespace Tests
             Utils.SaveResultsAsCSV(results, destinationFolder + "\\test.csv");
             string[] stringLines = File.ReadAllLines(destinationFolder + "\\test.csv");
             Assert.Equal(177, stringLines.Length);
-            Assert.Equal("File Name", stringLines[0].Split(',')[0].Trim());
+            Assert.Equal("File name", stringLines[0].Split(',')[0].Trim());
             Assert.Equal("1", stringLines[1].Split(',')[1].Trim());
             Assert.Equal("\"\tstring returnedLine = Utils.GetLine(body", stringLines[2].Split(',')[2].Trim());
         }
@@ -723,7 +723,7 @@ namespace Tests
             Utils.SaveResultsAsCSV(results, longDestinationFolder + "\\test.csv");
             string[] stringLines = File.ReadAllLines(longDestinationFolder + "\\test.csv");
             Assert.Equal(177, stringLines.Length);
-            Assert.Equal("File Name", stringLines[0].Split(',')[0].Trim());
+            Assert.Equal("File name", stringLines[0].Split(',')[0].Trim());
             Assert.Equal("1", stringLines[1].Split(',')[1].Trim());
             Assert.Equal("\"\tstring returnedLine = Utils.GetLine(body", stringLines[2].Split(',')[2].Trim());
         }

--- a/dnGREP.Localization/Properties/Resources.Designer.cs
+++ b/dnGREP.Localization/Properties/Resources.Designer.cs
@@ -331,7 +331,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to e.g. file??.*.
+        ///   Looks up a localized string similar to For example: *.txt;*.xml.
         /// </summary>
         public static string BookmarkDetails_ForExampleAsteriskPattern {
             get {
@@ -340,7 +340,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to e.g. file[0-9]{1,2}\\.txt.
+        ///   Looks up a localized string similar to For example: file[0-9]{1,2}\\.txt.
         /// </summary>
         public static string BookmarkDetails_ForExampleRegularExpession {
             get {
@@ -421,7 +421,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Asterisk pattern.
+        ///   Looks up a localized string similar to Wildcard.
         /// </summary>
         public static string BookmarkDetails_PatternType_AsteriskPattern {
             get {
@@ -439,7 +439,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Regex.
+        ///   Looks up a localized string similar to _Regular expression.
         /// </summary>
         public static string BookmarkDetails_PatternType_Regex {
             get {
@@ -475,7 +475,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex.
+        ///   Looks up a localized string similar to Byte.
         /// </summary>
         public static string BookmarkDetails_SearchType_Hex {
             get {
@@ -511,7 +511,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Read file as binary and search for bytes as hexadecimal digits: 68 65 78 20.
+        ///   Looks up a localized string similar to Byte search: read file as binary and search for bytes as hexadecimal digits: 68 65 78 20.
         /// </summary>
         public static string BookmarkDetails_SearchType_ReadFileAsBinaryAndSearchForBytes {
             get {
@@ -520,7 +520,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Regex.
+        ///   Looks up a localized string similar to _Regular expression.
         /// </summary>
         public static string BookmarkDetails_SearchType_Regex {
             get {
@@ -1316,7 +1316,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to e.g. file??.*.
+        ///   Looks up a localized string similar to For example: *.txt;*.xml.
         /// </summary>
         public static string Main_ForExampleAsteriskPattern {
             get {
@@ -1325,7 +1325,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to e.g. file[0-9]{1,2}\\.txt.
+        ///   Looks up a localized string similar to For example: file[0-9]{1,2}\\.txt.
         /// </summary>
         public static string Main_ForExampleRegularExpession {
             get {
@@ -1568,7 +1568,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Text Results.
+        ///   Looks up a localized string similar to Text results.
         /// </summary>
         public static string Main_MoreMenu_Save_TextResults {
             get {
@@ -1631,7 +1631,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Asterisk pattern.
+        ///   Looks up a localized string similar to Wildcard.
         /// </summary>
         public static string Main_PatternType_Asterisk {
             get {
@@ -1649,7 +1649,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Regex.
+        ///   Looks up a localized string similar to _Regular expression.
         /// </summary>
         public static string Main_PatternType_Regex {
             get {
@@ -1694,7 +1694,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CSV (comma delimited).
+        ///   Looks up a localized string similar to CSV (comma separated).
         /// </summary>
         public static string Main_ReportOption_CSVFileFormat {
             get {
@@ -2027,7 +2027,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Paralle_l.
+        ///   Looks up a localized string similar to Search paralle_l.
         /// </summary>
         public static string Main_SearchParallel {
             get {
@@ -2036,7 +2036,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex.
+        ///   Looks up a localized string similar to Byte.
         /// </summary>
         public static string Main_SearchType_Hex {
             get {
@@ -2072,7 +2072,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Read file as binary and search for bytes as hexadecimal digits: 68 65 78 20.
+        ///   Looks up a localized string similar to Byte search: read file as binary and search for bytes as hexadecimal digits: 68 65 78 20.
         /// </summary>
         public static string Main_SearchType_ReadFileAsBinaryAndSearchForBytes {
             get {
@@ -2081,7 +2081,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Regex.
+        ///   Looks up a localized string similar to _Regular expression.
         /// </summary>
         public static string Main_SearchType_Regex {
             get {
@@ -2090,7 +2090,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search using regular expressions.
+        ///   Looks up a localized string similar to Regular expression search.
         /// </summary>
         public static string Main_SearchType_RegularExpressionSearch {
             get {
@@ -2279,7 +2279,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace complete – replaced text in {0} files..
+        ///   Looks up a localized string similar to Replace completed – replaced text in {0} files..
         /// </summary>
         public static string Main_Status_ReplaceComplete0FilesReplaced {
             get {
@@ -2324,7 +2324,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Complete – searched {0} files, found {1} files in {2}..
+        ///   Looks up a localized string similar to Search completed – searched {0} files, found {1} files in {2}..
         /// </summary>
         public static string Main_Status_SearchCompleteSearched0FilesFound1FilesIn2 {
             get {
@@ -2423,7 +2423,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex string is not valid!.
+        ///   Looks up a localized string similar to Byte string is not valid!.
         /// </summary>
         public static string Main_Validation_HexStringIsNotValid {
             get {
@@ -2432,7 +2432,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex string is OK.
+        ///   Looks up a localized string similar to Byte string is OK.
         /// </summary>
         public static string Main_Validation_HexStringIsOK {
             get {
@@ -2441,7 +2441,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regex is not valid!.
+        ///   Looks up a localized string similar to Regular expression is not valid!.
         /// </summary>
         public static string Main_Validation_RegexIsNotValid {
             get {
@@ -2450,7 +2450,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regex is OK.
+        ///   Looks up a localized string similar to Regular expression is OK.
         /// </summary>
         public static string Main_Validation_RegexIsOK {
             get {
@@ -2729,7 +2729,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New version.
+        ///   Looks up a localized string similar to New Version.
         /// </summary>
         public static string MessageBox_NewVersion {
             get {
@@ -3089,7 +3089,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Application Fonts.
+        ///   Looks up a localized string similar to Application fonts.
         /// </summary>
         public static string Options_ApplicationFonts {
             get {
@@ -3368,7 +3368,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex search result line length.
+        ///   Looks up a localized string similar to Byte search result line length.
         /// </summary>
         public static string Options_HexSearchResultLineLength {
             get {
@@ -3503,7 +3503,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PDF to Text.
+        ///   Looks up a localized string similar to PDF to text.
         /// </summary>
         public static string Options_PDFToText {
             get {
@@ -3665,7 +3665,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sample Text.
+        ///   Looks up a localized string similar to Sample text.
         /// </summary>
         public static string Options_SampleText {
             get {
@@ -3800,7 +3800,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use Default.
+        ///   Looks up a localized string similar to Use default font.
         /// </summary>
         public static string Options_UseDefault {
             get {
@@ -4583,7 +4583,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Using regex file pattern.
+        ///   Looks up a localized string similar to Using regular expression file pattern.
         /// </summary>
         public static string ReportSummary_UsingRegexFilePattern {
             get {
@@ -4754,7 +4754,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Regex.
+        ///   Looks up a localized string similar to _Regular expression.
         /// </summary>
         public static string Test_SearchType_Regex {
             get {
@@ -4853,7 +4853,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hit F1 for more regex patterns.
+        ///   Looks up a localized string similar to Hit F1 for more regular expression patterns.
         /// </summary>
         public static string TTA7_ForMoreRegexPatternsHitF1 {
             get {
@@ -4862,7 +4862,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to $&amp; replaces entire regex.
+        ///   Looks up a localized string similar to $&amp; replaces entire regular expression.
         /// </summary>
         public static string TTB1_ReplacesEntireRegex {
             get {

--- a/dnGREP.Localization/Properties/Resources.Designer.cs
+++ b/dnGREP.Localization/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to About dnGREP.
+        ///   Looks up a localized string similar to About dnGrep.
         /// </summary>
         public static string About_AboutDnGREP {
             get {
@@ -97,7 +97,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to dnGREP.
+        ///   Looks up a localized string similar to dnGrep.
         /// </summary>
         public static string About_DnGREP {
             get {
@@ -124,7 +124,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Json framework for .NET.
+        ///   Looks up a localized string similar to JSON framework for .NET.
         /// </summary>
         public static string About_JsonFrameworkForNET {
             get {
@@ -241,7 +241,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Associated Folders:.
+        ///   Looks up a localized string similar to Associated folders:.
         /// </summary>
         public static string BookmarkDetails_AssociatedFolders {
             get {
@@ -304,7 +304,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Everything Index Service.
+        ///   Looks up a localized string similar to Everything index service.
         /// </summary>
         public static string BookmarkDetails_EverythingIndexService {
             get {
@@ -313,7 +313,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File Pattern Type.
+        ///   Looks up a localized string similar to File pattern type.
         /// </summary>
         public static string BookmarkDetails_FilePatternType {
             get {
@@ -556,7 +556,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XPath search (XML documents only).
+        ///   Looks up a localized string similar to XPath search (only for XML documents).
         /// </summary>
         public static string BookmarkDetails_SearchType_XPathSearchXMLDocumentsOnly {
             get {
@@ -583,7 +583,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type.
+        ///   Looks up a localized string similar to Search type.
         /// </summary>
         public static string BookmarkDetails_TypeHeader {
             get {
@@ -673,7 +673,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File Pattern.
+        ///   Looks up a localized string similar to File pattern.
         /// </summary>
         public static string Bookmarks_FilePatternHeader {
             get {
@@ -691,7 +691,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Other Properties.
+        ///   Looks up a localized string similar to Other properties.
         /// </summary>
         public static string Bookmarks_OtherPropertiesHeader {
             get {
@@ -700,7 +700,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace With.
+        ///   Looks up a localized string similar to Replace with.
         /// </summary>
         public static string Bookmarks_ReplaceWithHeader {
             get {
@@ -709,7 +709,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search For.
+        ///   Looks up a localized string similar to Search for.
         /// </summary>
         public static string Bookmarks_SearchForHeader {
             get {
@@ -727,7 +727,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Max folder depth {0}.
+        ///   Looks up a localized string similar to Max folder depth: {0}.
         /// </summary>
         public static string Bookmarks_Summary_MaxFolderDepth {
             get {
@@ -772,7 +772,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No symlinks.
+        ///   Looks up a localized string similar to No symbolic links.
         /// </summary>
         public static string Bookmarks_Summary_NoSymlinks {
             get {
@@ -866,7 +866,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more arguments are invalid..
+        ///   Looks up a localized string similar to One or more arguments are not valid..
         /// </summary>
         public static string Help_OneOrMoreArgumentsAreInvalid {
             get {
@@ -911,7 +911,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Date Modified:.
+        ///   Looks up a localized string similar to Date modified:.
         /// </summary>
         public static string Main_Attributes_DateModified {
             get {
@@ -956,7 +956,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto Position.
+        ///   Looks up a localized string similar to Auto position.
         /// </summary>
         public static string Main_AutoPosition {
             get {
@@ -1010,7 +1010,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Changes the results tree zoom.
+        ///   Looks up a localized string similar to Changes the zoom level of the results tree.
         /// </summary>
         public static string Main_ChangesTheResultsTreeZoom {
             get {
@@ -1055,7 +1055,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Context changes Will be applied in next search.
+        ///   Looks up a localized string similar to Context line changes will be applied in next search.
         /// </summary>
         public static string Main_ContextChangesWillBeAppliedInNextSearch {
             get {
@@ -1118,7 +1118,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to dnGREP.
+        ///   Looks up a localized string similar to dnGrep.
         /// </summary>
         public static string Main_DnGREP_Title {
             get {
@@ -1127,7 +1127,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dock Bottom.
+        ///   Looks up a localized string similar to Dock bottom.
         /// </summary>
         public static string Main_DockBottom {
             get {
@@ -1136,7 +1136,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dock Right.
+        ///   Looks up a localized string similar to Dock right.
         /// </summary>
         public static string Main_DockRight {
             get {
@@ -1181,7 +1181,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Everything Index Service.
+        ///   Looks up a localized string similar to Everything index service.
         /// </summary>
         public static string Main_EverythingIndexService {
             get {
@@ -1226,7 +1226,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to By Created Date.
+        ///   Looks up a localized string similar to By created date.
         /// </summary>
         public static string Main_FilterSummary_ByCreatedDate {
             get {
@@ -1235,7 +1235,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to By Modified Date.
+        ///   Looks up a localized string similar to By modified date.
         /// </summary>
         public static string Main_FilterSummary_ByModifiedDate {
             get {
@@ -1244,7 +1244,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to By Size.
+        ///   Looks up a localized string similar to By size.
         /// </summary>
         public static string Main_FilterSummary_BySize {
             get {
@@ -1253,7 +1253,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Max folder depth {0}.
+        ///   Looks up a localized string similar to Max folder depth: {0}.
         /// </summary>
         public static string Main_FilterSummary_MaxFolderDepth {
             get {
@@ -1289,7 +1289,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No symlinks.
+        ///   Looks up a localized string similar to No symbolic links.
         /// </summary>
         public static string Main_FilterSummary_NoSymlinks {
             get {
@@ -1352,7 +1352,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Highlight Groups.
+        ///   Looks up a localized string similar to Highlight groups.
         /// </summary>
         public static string Main_HighlightGroups {
             get {
@@ -1361,7 +1361,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Highlight Matches.
+        ///   Looks up a localized string similar to Highlight matches.
         /// </summary>
         public static string Main_HighlightMatches {
             get {
@@ -1370,7 +1370,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Highlight regular expression groups - changes will be applied in next search.
+        ///   Looks up a localized string similar to Highlight regular expression groups. Changes will be applied in next search..
         /// </summary>
         public static string Main_HighlightRegularExpressionGroups {
             get {
@@ -1433,7 +1433,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _About dnGrep....
+        ///   Looks up a localized string similar to _About dnGrep….
         /// </summary>
         public static string Main_Menu_About_AboutDnGrep {
             get {
@@ -1451,7 +1451,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Bookmarks....
+        ///   Looks up a localized string similar to _Bookmarks….
         /// </summary>
         public static string Main_Menu_Bookmarks {
             get {
@@ -1460,7 +1460,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Options....
+        ///   Looks up a localized string similar to _Options….
         /// </summary>
         public static string Main_Menu_Options {
             get {
@@ -1487,7 +1487,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Mor_e....
+        ///   Looks up a localized string similar to Mor_e….
         /// </summary>
         public static string Main_More {
             get {
@@ -1514,7 +1514,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy files....
+        ///   Looks up a localized string similar to Copy files….
         /// </summary>
         public static string Main_MoreMenu_CopyFiles {
             get {
@@ -1532,7 +1532,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete files....
+        ///   Looks up a localized string similar to Delete files….
         /// </summary>
         public static string Main_MoreMenu_DeleteFiles {
             get {
@@ -1541,7 +1541,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move files....
+        ///   Looks up a localized string similar to Move files….
         /// </summary>
         public static string Main_MoreMenu_MoveFiles {
             get {
@@ -1550,7 +1550,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CSV Results.
+        ///   Looks up a localized string similar to CSV results.
         /// </summary>
         public static string Main_MoreMenu_Save_CSVResults {
             get {
@@ -1595,7 +1595,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ....
+        ///   Looks up a localized string similar to ….
         /// </summary>
         public static string Main_OpenFolder {
             get {
@@ -1694,7 +1694,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to CSV file format.
+        ///   Looks up a localized string similar to CSV (comma delimited).
         /// </summary>
         public static string Main_ReportOption_CSVFileFormat {
             get {
@@ -1703,7 +1703,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Report file format.
+        ///   Looks up a localized string similar to Report format.
         /// </summary>
         public static string Main_ReportOption_ReportFileFormat {
             get {
@@ -1712,7 +1712,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Results file format.
+        ///   Looks up a localized string similar to Text file.
         /// </summary>
         public static string Main_ReportOption_ResultsFileFormat {
             get {
@@ -1721,7 +1721,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset Options.
+        ///   Looks up a localized string similar to Reset filters.
         /// </summary>
         public static string Main_ResetOptions {
             get {
@@ -1739,7 +1739,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (at end of line).
+        ///   Looks up a localized string similar to (at end of the line).
         /// </summary>
         public static string Main_ResultList_AtEndOfLine {
             get {
@@ -1757,7 +1757,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ...(+{0:n0} characters).
+        ///   Looks up a localized string similar to …(+{0:n0} characters).
         /// </summary>
         public static string Main_ResultList_CountAdditionalCharacters {
             get {
@@ -1793,7 +1793,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Match {0}{1}Group {2}:   {3}.
+        ///   Looks up a localized string similar to Match {0}{1}Group {2}: {3}.
         /// </summary>
         public static string Main_ResultList_MatchToolTip2 {
             get {
@@ -1856,7 +1856,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy Lines of text.
+        ///   Looks up a localized string similar to Copy lines of text.
         /// </summary>
         public static string Main_Results_CopyLinesOfText {
             get {
@@ -1883,7 +1883,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Next Match.
+        ///   Looks up a localized string similar to Next match.
         /// </summary>
         public static string Main_Results_NextMatch {
             get {
@@ -1919,7 +1919,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Previous Match.
+        ///   Looks up a localized string similar to Previous match.
         /// </summary>
         public static string Main_Results_PreviousMatch {
             get {
@@ -1955,7 +1955,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Saving results to file....
+        ///   Looks up a localized string similar to Saving results to file….
         /// </summary>
         public static string Main_SavingResultsToFile {
             get {
@@ -2090,7 +2090,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regular expression search.
+        ///   Looks up a localized string similar to Search using regular expressions.
         /// </summary>
         public static string Main_SearchType_RegularExpressionSearch {
             get {
@@ -2117,7 +2117,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XPath search (XML documents only).
+        ///   Looks up a localized string similar to XPath search (only for XML documents).
         /// </summary>
         public static string Main_SearchType_XPathSearchXMLDocumentsOnly {
             get {
@@ -2270,7 +2270,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace Canceled.
+        ///   Looks up a localized string similar to Replace canceled.
         /// </summary>
         public static string Main_Status_ReplaceCanceled {
             get {
@@ -2279,7 +2279,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace Complete - {0} files replaced..
+        ///   Looks up a localized string similar to Replace complete – replaced text in {0} files..
         /// </summary>
         public static string Main_Status_ReplaceComplete0FilesReplaced {
             get {
@@ -2288,7 +2288,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace Failed..
+        ///   Looks up a localized string similar to Replace failed.
         /// </summary>
         public static string Main_Status_ReplaceFailed {
             get {
@@ -2297,7 +2297,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replacing....
+        ///   Looks up a localized string similar to Replacing….
         /// </summary>
         public static string Main_Status_Replacing {
             get {
@@ -2306,7 +2306,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Canceled.
+        ///   Looks up a localized string similar to Search canceled.
         /// </summary>
         public static string Main_Status_SearchCanceled {
             get {
@@ -2315,7 +2315,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Canceled or Failed.
+        ///   Looks up a localized string similar to Search canceled or failed.
         /// </summary>
         public static string Main_Status_SearchCanceledOrFailed {
             get {
@@ -2324,7 +2324,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search Complete - Searched {0} files. Found {1} files in {2}..
+        ///   Looks up a localized string similar to Search Complete – searched {0} files, found {1} files in {2}..
         /// </summary>
         public static string Main_Status_SearchCompleteSearched0FilesFound1FilesIn2 {
             get {
@@ -2333,7 +2333,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searched {0} files. Found {1} matching files..
+        ///   Looks up a localized string similar to Searched {0} files, found {1} matching files..
         /// </summary>
         public static string Main_Status_Searched0FilesFound1MatchingFiles {
             get {
@@ -2342,7 +2342,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searched {0} files. Found {1} matching files - processing {2}.
+        ///   Looks up a localized string similar to Searched {0} files, found {1} matching files – processing {2}.
         /// </summary>
         public static string Main_Status_Searched0FilesFound1MatchingFilesProcessing2 {
             get {
@@ -2351,7 +2351,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searching....
+        ///   Looks up a localized string similar to Searching….
         /// </summary>
         public static string Main_Status_Searching {
             get {
@@ -2378,7 +2378,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Test Expression.
+        ///   Looks up a localized string similar to Test expression.
         /// </summary>
         public static string Main_TestExpression {
             get {
@@ -2396,7 +2396,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use capture groups from &apos;Paths to match&apos; in the &apos;Search for&apos; pattern.
+        ///   Looks up a localized string similar to Use capture groups from &apos;Patterns to match&apos; in the &apos;Search for&apos; pattern.
         /// </summary>
         public static string Main_UseCaptureGroupsFromPathsToMatch {
             get {
@@ -2432,7 +2432,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hex string is OK!.
+        ///   Looks up a localized string similar to Hex string is OK.
         /// </summary>
         public static string Main_Validation_HexStringIsOK {
             get {
@@ -2450,7 +2450,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regex is OK!.
+        ///   Looks up a localized string similar to Regex is OK.
         /// </summary>
         public static string Main_Validation_RegexIsOK {
             get {
@@ -2468,7 +2468,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XPath is OK!.
+        ///   Looks up a localized string similar to XPath is OK.
         /// </summary>
         public static string Main_Validation_XPathIsOK {
             get {
@@ -2486,7 +2486,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} in &quot;{1}&quot; - dnGREP.
+        ///   Looks up a localized string similar to {0} in &quot;{1}&quot; – dnGrep.
         /// </summary>
         public static string Main_WindowTitle {
             get {
@@ -2495,7 +2495,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Wrap Text.
+        ///   Looks up a localized string similar to Wrap text.
         /// </summary>
         public static string Main_WrapText {
             get {
@@ -2513,7 +2513,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to continue?.
+        ///   Looks up a localized string similar to Continue?.
         /// </summary>
         public static string MessageBox_AreYouSureYouWantToContinue {
             get {
@@ -2522,7 +2522,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to replace search pattern with empty string?.
+        ///   Looks up a localized string similar to Replace the search pattern with an empty string?.
         /// </summary>
         public static string MessageBox_AreYouSureYouWantToReplaceSearchPatternWithEmptyString {
             get {
@@ -2531,7 +2531,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check editor path via &quot;Options...&quot;..
+        ///   Looks up a localized string similar to Check editor path via &quot;Options…&quot;..
         /// </summary>
         public static string MessageBox_CheckEditorPath {
             get {
@@ -2540,7 +2540,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clearing this bookmark will also clear that bookmark..
+        ///   Looks up a localized string similar to Clearing this bookmark also clears that bookmark..
         /// </summary>
         public static string MessageBox_ClearingThisBookmarkWillAlsoClearThatBookmark {
             get {
@@ -2549,7 +2549,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clearing this bookmark will also remove those bookmarks..
+        ///   Looks up a localized string similar to Clearing this bookmark also removes those bookmarks..
         /// </summary>
         public static string MessageBox_ClearingThisBookmarkWillAlsoRemoveThoseBookmarks {
             get {
@@ -2567,7 +2567,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not load resources file &apos;{0}&apos;: .
+        ///   Looks up a localized string similar to Could not load the &apos;{0}&apos; resources file: .
         /// </summary>
         public static string MessageBox_CouldNotLoadResourcesFile0 {
             get {
@@ -2576,7 +2576,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not load theme &apos;{0}&apos;, See the error log for details: .
+        ///   Looks up a localized string similar to Could not load the &apos;{0}&apos; theme. Check the error log for details: .
         /// </summary>
         public static string MessageBox_CouldNotLoadTheme {
             get {
@@ -2585,7 +2585,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} files have been successfully copied..
+        ///   Looks up a localized string similar to {0} files have been copied..
         /// </summary>
         public static string MessageBox_CountFilesHaveBeenSuccessfullyCopied {
             get {
@@ -2594,7 +2594,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} files have been successfully deleted..
+        ///   Looks up a localized string similar to {0} files have been deleted..
         /// </summary>
         public static string MessageBox_CountFilesHaveBeenSuccessfullyDeleted {
             get {
@@ -2603,7 +2603,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} files have been successfully moved..
+        ///   Looks up a localized string similar to {0} files have been moved..
         /// </summary>
         public static string MessageBox_CountFilesHaveBeenSuccessfullyMoved {
             get {
@@ -2612,7 +2612,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error opening file by custom editor..
+        ///   Looks up a localized string similar to Could not open the file with the custom editor..
         /// </summary>
         public static string MessageBox_CustomEditorFileOpenError {
             get {
@@ -2621,7 +2621,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default engine was used instead..
+        ///   Looks up a localized string similar to The default engine was used instead..
         /// </summary>
         public static string MessageBox_DefaultEngineWasUsedInstead {
             get {
@@ -2648,7 +2648,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do you want to continue?.
+        ///   Looks up a localized string similar to Continue?.
         /// </summary>
         public static string MessageBox_DoYouWantToContinue {
             get {
@@ -2666,7 +2666,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error opening file. See the error log for details: .
+        ///   Looks up a localized string similar to Could not open the file. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ErrorOpeningFile {
             get {
@@ -2675,7 +2675,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error setting clipboard text, the clipboard is locked by.
+        ///   Looks up a localized string similar to Could not set clipboard text. The clipboard is locked by.
         /// </summary>
         public static string MessageBox_ErrorSettingClipboardTextTheClipboardIsLockedBy {
             get {
@@ -2684,7 +2684,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to extract file from archive. See the error log for details: .
+        ///   Looks up a localized string similar to Could not extract file from archive. Check the error log for details: .
         /// </summary>
         public static string MessageBox_FailedToExtractFileFromArchive {
             get {
@@ -2693,7 +2693,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Files have been successfully reverted..
+        ///   Looks up a localized string similar to Files have been reverted..
         /// </summary>
         public static string MessageBox_FilesHaveBeenSuccessfullyReverted {
             get {
@@ -2738,7 +2738,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New version of dnGREP ({0}) is available for download..
+        ///   Looks up a localized string similar to New version of dnGrep ({0}) is available for download..
         /// </summary>
         public static string MessageBox_NewVersionOfDnGREP0IsAvailableForDownload {
             get {
@@ -2756,7 +2756,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugin Errors.
+        ///   Looks up a localized string similar to Plug-in Errors.
         /// </summary>
         public static string MessageBox_PluginErrors {
             get {
@@ -2765,7 +2765,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename failed: .
+        ///   Looks up a localized string similar to Could not rename the file: .
         /// </summary>
         public static string MessageBox_RenameFailed {
             get {
@@ -2792,7 +2792,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace failed! See the error log for details: .
+        ///   Looks up a localized string similar to Could not replace text in files. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ReplaceFailedError {
             get {
@@ -2810,7 +2810,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run dnGrep as Administrator to change showing dnGrep in Explorer right-click menu.
+        ///   Looks up a localized string similar to Run dnGrep as Administrator to change showing dnGrep in Windows Explorer right-click menu.
         /// </summary>
         public static string MessageBox_RunDnGrepAsAdministrator {
             get {
@@ -2819,7 +2819,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run dnGrep as Administrator to change Startup Register.
+        ///   Looks up a localized string similar to Run dnGrep as Administrator to change application startup option..
         /// </summary>
         public static string MessageBox_RunDnGrepAsAdministratorToChangeStartupRegister {
             get {
@@ -2828,7 +2828,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search failed! See the error log for details: .
+        ///   Looks up a localized string similar to Could not complete the search. Check the error log for details: .
         /// </summary>
         public static string MessageBox_SearchFailedError {
             get {
@@ -2837,7 +2837,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search or replace failed! See the error log for details: .
+        ///   Looks up a localized string similar to Could not complete the search or replace. Check the error log for details: .
         /// </summary>
         public static string MessageBox_SearchOrReplaceFailed {
             get {
@@ -2846,7 +2846,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search path in the &apos;{0}&apos; field is not valid, search canceled..
+        ///   Looks up a localized string similar to The search path in the &apos;{0}&apos; field is not valid, search canceled..
         /// </summary>
         public static string MessageBox_SearchPathInTheFieldIsNotValid {
             get {
@@ -2873,7 +2873,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Something broke down in dnGrep. See the error log for details: .
+        ///   Looks up a localized string similar to Something broke down in dnGrep. Check the error log for details: .
         /// </summary>
         public static string MessageBox_SomethingBrokeDownInDnGrep {
             get {
@@ -2882,7 +2882,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file &apos;{0}&apos; already exists in {1}, overwrite existing?.
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; already exists in {1}. Overwrite existing?.
         /// </summary>
         public static string MessageBox_TheFile0AlreadyExistsIn1OverwriteExisting {
             get {
@@ -2900,7 +2900,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following plugins failed to load:.
+        ///   Looks up a localized string similar to Could not load the following plug-ins:.
         /// </summary>
         public static string MessageBox_TheFollowingPluginsFailedToLoad {
             get {
@@ -2909,7 +2909,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error adding dnGrep to Explorer right-click menu. See the error log for details: .
+        ///   Looks up a localized string similar to Could not add dnGrep to the Windows Explorer right-click menu. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorAddingDnGrepToExplorerRightClickMenu {
             get {
@@ -2918,7 +2918,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error copying files. See the error log for details: .
+        ///   Looks up a localized string similar to Could not copy the files. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorCopyingFiles {
             get {
@@ -2927,7 +2927,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error creating the file. See the error log for details: .
+        ///   Looks up a localized string similar to Could not create the file. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorCreatingTheFile {
             get {
@@ -2936,7 +2936,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error deleting files. See the error log for details: .
+        ///   Looks up a localized string similar to Could not delete the files. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorDeletingFiles {
             get {
@@ -2945,7 +2945,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error moving files. See the error log for details: .
+        ///   Looks up a localized string similar to Could not move the files. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorMovingFiles {
             get {
@@ -2954,7 +2954,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error registering auto startup. See the error log for details: .
+        ///   Looks up a localized string similar to Could not register auto startup. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorRegisteringAutoStartup {
             get {
@@ -2963,7 +2963,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error removing dnGrep from the Explorer right-click menu. See the error log for details: .
+        ///   Looks up a localized string similar to Could not remove dnGrep from the Windows Explorer right-click menu. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorRemovingDnGrepFromTheExplorerRightClickMenu {
             get {
@@ -2972,7 +2972,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error reverting files. See the error log for details: .
+        ///   Looks up a localized string similar to Could not revert files. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorRevertingFiles {
             get {
@@ -2981,7 +2981,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error running the test window. See the error log for details: .
+        ///   Looks up a localized string similar to Could not open the test window. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorRunningRegexTest {
             get {
@@ -2990,7 +2990,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error saving options. See the error log for details: .
+        ///   Looks up a localized string similar to Could not save options. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorSavingOptions {
             get {
@@ -2999,7 +2999,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There was an error unregistering auto startup. See the error log for details: .
+        ///   Looks up a localized string similar to Could not unregister auto startup. Check the error log for details: .
         /// </summary>
         public static string MessageBox_ThereWasAnErrorUnregisteringAutoStartup {
             get {
@@ -3008,7 +3008,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This bookmark is associated with {0} other folders:.
+        ///   Looks up a localized string similar to This bookmark is associated with {0} other folders..
         /// </summary>
         public static string MessageBox_ThisBookmarkIsAssociatedWith0OtherFolders {
             get {
@@ -3017,7 +3017,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This bookmark is associated with one other folder.
+        ///   Looks up a localized string similar to This bookmark is associated with one other folder..
         /// </summary>
         public static string MessageBox_ThisBookmarkIsAssociatedWithOneOtherFolder {
             get {
@@ -3044,7 +3044,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Window Title: {0}.
+        ///   Looks up a localized string similar to Window title: {0}.
         /// </summary>
         public static string MessageBox_WindowTitleIsName {
             get {
@@ -3053,7 +3053,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Would you like to continue?.
+        ///   Looks up a localized string similar to Continue?.
         /// </summary>
         public static string MessageBox_WouldYouLikeToContinue {
             get {
@@ -3062,7 +3062,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Would you like to download it now?.
+        ///   Looks up a localized string similar to Download it now?.
         /// </summary>
         public static string MessageBox_WouldYouLikeToDownloadItNow {
             get {
@@ -3080,7 +3080,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow searching for file name pattern only when &apos;Search for&apos; is empty.
+        ///   Looks up a localized string similar to List files using the file name pattern when the &apos;Search for&apos; field is empty.
         /// </summary>
         public static string Options_AllowSearchingForFileNamePatternOnly {
             get {
@@ -3098,7 +3098,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add:.
+        ///   Looks up a localized string similar to Add.
         /// </summary>
         public static string Options_ArchiveAdd {
             get {
@@ -3107,7 +3107,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default:.
+        ///   Looks up a localized string similar to Default.
         /// </summary>
         public static string Options_ArchiveDefault {
             get {
@@ -3125,7 +3125,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Archive Options.
+        ///   Looks up a localized string similar to Archive files.
         /// </summary>
         public static string Options_ArchiveOptions {
             get {
@@ -3134,7 +3134,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove:.
+        ///   Looks up a localized string similar to Remove.
         /// </summary>
         public static string Options_ArchiveRemove {
             get {
@@ -3143,7 +3143,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ....
+        ///   Looks up a localized string similar to ….
         /// </summary>
         public static string Options_BrowseFileLocation {
             get {
@@ -3161,7 +3161,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Check for updates when Windows starts.
+        ///   Looks up a localized string similar to Check for new versions when Windows starts.
         /// </summary>
         public static string Options_CheckForUpdatesWhenWindowsStarts {
             get {
@@ -3170,7 +3170,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checking for updates.
+        ///   Looks up a localized string similar to New versions.
         /// </summary>
         public static string Options_CheckingForUpdates {
             get {
@@ -3260,7 +3260,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Detect file encoding when searching for file name pattern only.
+        ///   Looks up a localized string similar to Detect file encoding when listing files using the file name pattern.
         /// </summary>
         public static string Options_DetectFileEncodingWhenSearchingForFileNamePatternOnly {
             get {
@@ -3269,7 +3269,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dialog Font Size.
+        ///   Looks up a localized string similar to Other windows font size.
         /// </summary>
         public static string Options_DialogFontSize {
             get {
@@ -3278,7 +3278,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to dnGrep will add the selected files to the end of the command line..
+        ///   Looks up a localized string similar to dnGrep will add the selected files to the end of the command-line..
         /// </summary>
         public static string Options_DnGrepWillAddTheSelectedFiles {
             get {
@@ -3305,7 +3305,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable automatic checking every.
+        ///   Looks up a localized string similar to Check automatically every.
         /// </summary>
         public static string Options_EnableAutomaticCheckingEvery {
             get {
@@ -3341,7 +3341,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Follow Windows Theme.
+        ///   Looks up a localized string similar to Follow Windows theme.
         /// </summary>
         public static string Options_FollowWindowsTheme {
             get {
@@ -3350,7 +3350,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Font Family.
+        ///   Looks up a localized string similar to Font family.
         /// </summary>
         public static string Options_FontFamily {
             get {
@@ -3377,7 +3377,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to History Lists.
+        ///   Looks up a localized string similar to History lists.
         /// </summary>
         public static string Options_HistoryLists {
             get {
@@ -3440,7 +3440,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Load from file....
+        ///   Looks up a localized string similar to Load from file….
         /// </summary>
         public static string Options_LoadFromFile {
             get {
@@ -3449,7 +3449,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Main Font Size.
+        ///   Looks up a localized string similar to Main window font size.
         /// </summary>
         public static string Options_MainFontSize {
             get {
@@ -3458,7 +3458,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 0 - match everything; 1.0 - exact match.
+        ///   Looks up a localized string similar to 0 – match everything; 1.0 – exact match.
         /// </summary>
         public static string Options_MatchEverythingToExactMatch {
             get {
@@ -3485,7 +3485,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to on main panel.
+        ///   Looks up a localized string similar to on the main panel.
         /// </summary>
         public static string Options_OnMainPanel {
             get {
@@ -3512,7 +3512,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PdfToText.exe command line options:.
+        ///   Looks up a localized string similar to PdfToText.exe command-line options:.
         /// </summary>
         public static string Options_PdfToTextExeCommandLineOptions {
             get {
@@ -3539,7 +3539,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add:.
+        ///   Looks up a localized string similar to Add.
         /// </summary>
         public static string Options_PluginAdd {
             get {
@@ -3548,7 +3548,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default:.
+        ///   Looks up a localized string similar to Default.
         /// </summary>
         public static string Options_PluginDefault {
             get {
@@ -3575,7 +3575,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugin Options.
+        ///   Looks up a localized string similar to Plug-ins.
         /// </summary>
         public static string Options_PluginOptions {
             get {
@@ -3584,7 +3584,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove:.
+        ///   Looks up a localized string similar to Remove.
         /// </summary>
         public static string Options_PluginRemove {
             get {
@@ -3593,7 +3593,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Press F1 for help on Options.
+        ///   Looks up a localized string similar to Press F1 for help on options.
         /// </summary>
         public static string Options_PressF1ForHelpOnOptions {
             get {
@@ -3611,7 +3611,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Regex Options.
+        ///   Looks up a localized string similar to Regular expressions.
         /// </summary>
         public static string Options_RegexOptions {
             get {
@@ -3638,7 +3638,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace dialog Layout:.
+        ///   Looks up a localized string similar to Replace window layout.
         /// </summary>
         public static string Options_ReplaceDialogLayout {
             get {
@@ -3647,7 +3647,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace Font Size.
+        ///   Looks up a localized string similar to Replace window font size.
         /// </summary>
         public static string Options_ReplaceFontSize {
             get {
@@ -3656,7 +3656,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Results Options.
+        ///   Looks up a localized string similar to Search results.
         /// </summary>
         public static string Options_ResultsOptions {
             get {
@@ -3683,7 +3683,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Selected Theme.
+        ///   Looks up a localized string similar to Selected theme.
         /// </summary>
         public static string Options_SelectedTheme {
             get {
@@ -3692,7 +3692,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show dnGrep in Explorer right-click menu.
+        ///   Looks up a localized string similar to Show dnGrep in the right-click menu of Windows Explorer.
         /// </summary>
         public static string Options_ShowDnGrepInExplorerRightClickMenu {
             get {
@@ -3701,7 +3701,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show file info tool tips.
+        ///   Looks up a localized string similar to Show file info tooltips.
         /// </summary>
         public static string Options_ShowFileInfoToolTips {
             get {
@@ -3710,7 +3710,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show file path in results panel.
+        ///   Looks up a localized string similar to Show file path in the results panel.
         /// </summary>
         public static string Options_ShowFilePathInResultsPanel {
             get {
@@ -3737,7 +3737,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show search options:.
+        ///   Looks up a localized string similar to Show search options.
         /// </summary>
         public static string Options_ShowSearchOptions {
             get {
@@ -3746,7 +3746,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show verbose match count.
+        ///   Looks up a localized string similar to Show additional details about the matches found.
         /// </summary>
         public static string Options_ShowVerboseMatchCount {
             get {
@@ -3755,7 +3755,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Startup options.
+        ///   Looks up a localized string similar to Startup.
         /// </summary>
         public static string Options_StartupOptions {
             get {
@@ -3764,7 +3764,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The match timeout limits how long the regular expression engine will attempt to resolve a regular expression before it times out. This prevents processing expressions and input strings that require excessive backtracking..
+        ///   Looks up a localized string similar to The match timeout limits how long the regular expression engine attempts to resolve a regular expression before it times out. It prevents processing expressions and input strings requiring excessive backtracking..
         /// </summary>
         public static string Options_TheMatchTimeoutLimits {
             get {
@@ -3791,7 +3791,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To change this setting run dnGREP as Administrator..
+        ///   Looks up a localized string similar to Run dnGrep as Administrator to change this setting..
         /// </summary>
         public static string Options_ToChangeThisSettingRunDnGREPAsAdministrator {
             get {
@@ -3845,7 +3845,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Highlights disabled: too many matches found..
+        ///   Looks up a localized string similar to Not showing highlights because too many matches were found..
         /// </summary>
         public static string Preview_HighlightsDisabledTooManyMatchesFound {
             get {
@@ -3890,7 +3890,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This file is either binary or too large to preview..
+        ///   Looks up a localized string similar to This file is either binary, or too large to be shown..
         /// </summary>
         public static string Preview_ThisFileIsEitherBinaryOrTooLargeToPreview {
             get {
@@ -3908,7 +3908,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Wrap Text.
+        ///   Looks up a localized string similar to Wrap text.
         /// </summary>
         public static string Preview_WrapText {
             get {
@@ -3998,7 +3998,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File {0} of {1}: {2}  ({3} matches on {4} lines).
+        ///   Looks up a localized string similar to File {0} of {1}: {2} ({3} matches on {4} lines).
         /// </summary>
         public static string Replace_FileNumberOfCountName {
             get {
@@ -4070,7 +4070,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Next _File.
+        ///   Looks up a localized string similar to Next _file.
         /// </summary>
         public static string Replace_NextFile {
             get {
@@ -4106,7 +4106,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Previous File.
+        ///   Looks up a localized string similar to Previous file.
         /// </summary>
         public static string Replace_PreviousFile {
             get {
@@ -4142,7 +4142,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace in All Files.
+        ///   Looks up a localized string similar to Replace in all files.
         /// </summary>
         public static string Replace_ReplaceInAllFiles {
             get {
@@ -4151,7 +4151,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace in File.
+        ///   Looks up a localized string similar to Replace in file.
         /// </summary>
         public static string Replace_ReplaceInFile {
             get {
@@ -4169,7 +4169,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Selected Match.
+        ///   Looks up a localized string similar to Selected match.
         /// </summary>
         public static string Replace_ReplaceKey2_SelectedMatch {
             get {
@@ -4178,7 +4178,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace Match.
+        ///   Looks up a localized string similar to Replace match.
         /// </summary>
         public static string Replace_ReplaceKey3_ReplaceMatch {
             get {
@@ -4187,7 +4187,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Skip Match.
+        ///   Looks up a localized string similar to Skip match.
         /// </summary>
         public static string Replace_ReplaceKey4_SkipMatch {
             get {
@@ -4259,7 +4259,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This file contains too many matches for individual replace.  To replace all of them, click &apos;Replace in File&apos;.
+        ///   Looks up a localized string similar to This file contains too many matches for individual replace. Click &apos;Replace in file&apos; to replace all of them..
         /// </summary>
         public static string Replace_ThisFileContainsTooManyMatchesForIndividualReplace {
             get {
@@ -4286,7 +4286,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Undo File.
+        ///   Looks up a localized string similar to Undo file.
         /// </summary>
         public static string Replace_UndoFile {
             get {
@@ -4304,7 +4304,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Wrap Text.
+        ///   Looks up a localized string similar to Wrap text.
         /// </summary>
         public static string Replace_WrapText {
             get {
@@ -4421,7 +4421,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exclude pattern:.
+        ///   Looks up a localized string similar to Exclude file pattern:.
         /// </summary>
         public static string ReportSummary_ExcludePattern {
             get {
@@ -4430,7 +4430,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File pattern:.
+        ///   Looks up a localized string similar to Include file pattern:.
         /// </summary>
         public static string ReportSummary_FilePattern {
             get {
@@ -4439,7 +4439,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Max folder depth {0}.
+        ///   Looks up a localized string similar to Max folder depth: {0}.
         /// </summary>
         public static string ReportSummary_MaxFolderDepth {
             get {
@@ -4502,7 +4502,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No symlinks.
+        ///   Looks up a localized string similar to No symbolic links.
         /// </summary>
         public static string ReportSummary_NoSymlinks {
             get {
@@ -4547,7 +4547,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Stop after frist match.
+        ///   Looks up a localized string similar to Stop after first match.
         /// </summary>
         public static string ReportSummary_StopAfterFirstMatch {
             get {
@@ -4691,7 +4691,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replace text is not valid XML!.
+        ///   Looks up a localized string similar to The replace text is not valid XML!.
         /// </summary>
         public static string Test_ReplaceTextIsNotValidXML {
             get {
@@ -4853,7 +4853,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For more Regex patterns hit F1.
+        ///   Looks up a localized string similar to Hit F1 for more regex patterns.
         /// </summary>
         public static string TTA7_ForMoreRegexPatternsHitF1 {
             get {
@@ -4871,7 +4871,7 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to $1, $2, $3, etc... inserts the text matched between capturing parentheses into the replacement text.
+        ///   Looks up a localized string similar to $1, $2, $3, etc… inserts the text matched between capturing parentheses into the replacement text.
         /// </summary>
         public static string TTB2_InsertsTheTextMatchedIntoTheReplacementText {
             get {

--- a/dnGREP.Localization/Properties/Resources.resx
+++ b/dnGREP.Localization/Properties/Resources.resx
@@ -227,7 +227,7 @@
   </data>
   <data name="BookmarkDetails_EverythingIndexService" xml:space="preserve">
     <value>Everything index service</value>
-    <comment>Bookmark details dialog, pattern type option Everything tooltip</comment>
+    <comment>Bookmark details dialog, Everything pattern type option tooltip</comment>
   </data>
   <data name="BookmarkDetails_FilePatternType" xml:space="preserve">
     <value>File pattern type</value>
@@ -238,18 +238,18 @@
     <comment>Bookmark details dialog, filter files checkbox label (accel)</comment>
   </data>
   <data name="BookmarkDetails_ForExampleAsteriskPattern" xml:space="preserve">
-    <value>e.g. file??.*</value>
-    <comment>Bookmark details dialog, pattern type option Asterisk tooltip</comment>
+    <value>For example: *.txt;*.xml</value>
+    <comment>Bookmark details dialog, Wildcard pattern type option tooltip</comment>
   </data>
   <data name="BookmarkDetails_ForExampleRegularExpession" xml:space="preserve">
-    <value>e.g. file[0-9]{1,2}\\.txt</value>
-    <comment>Bookmark details dialog, pattern type option Regex tooltip</comment>
+    <value>For example: file[0-9]{1,2}\\.txt</value>
+    <comment>Bookmark details dialog, regular expression pattern type option tooltip</comment>
   </data>
   <data name="BookmarkDetails_IncludeBinaryFiles" xml:space="preserve">
     <value>Include binary files</value>
     <comment>Bookmark details dialog, filter files checkbox label (accel)</comment>
   </data>
-  <data name="BookmarkDetails_IncludeHiddenFolders" xml:space="preserve">    
+  <data name="BookmarkDetails_IncludeHiddenFolders" xml:space="preserve">
     <value>Include hidden folders</value>
     <comment>Bookmark details dialog, filter files checkbox label (accel)</comment>
   </data>
@@ -278,16 +278,16 @@
     <comment>Bookmark details dialog, Patterns to match label</comment>
   </data>
   <data name="BookmarkDetails_PatternType_AsteriskPattern" xml:space="preserve">
-    <value>Asterisk pattern</value>
-    <comment>Bookmark details dialog, pattern type radio button label (accel)</comment>
+    <value>Wildcard</value>
+    <comment>Bookmark details dialog, Wildcard pattern type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_PatternType_Everything" xml:space="preserve">
     <value>Everything</value>
-    <comment>Bookmark details dialog, pattern type radio button label (accel)</comment>
+    <comment>Bookmark details dialog, Everything pattern type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_PatternType_Regex" xml:space="preserve">
-    <value>_Regex</value>
-    <comment>Bookmark details dialog, pattern type radio button label (accel)</comment>
+    <value>_Regular expression</value>
+    <comment>Bookmark details dialog, Regular expression pattern type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_ReplaceWith" xml:space="preserve">
     <value>Replace with:</value>
@@ -302,32 +302,32 @@
     <comment>Bookmark details dialog, checkbox label (accel)</comment>
   </data>
   <data name="BookmarkDetails_SearchType_Hex" xml:space="preserve">
-    <value>Hex</value>
-    <comment>Bookmark details dialog, search type radio button label (accel)</comment>
+    <value>Byte</value>
+    <comment>Bookmark details dialog, Byte search type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_SearchType_Phonetic" xml:space="preserve">
     <value>Phonetic</value>
-    <comment>Bookmark details dialog, search type radio button label (accel)</comment>
+    <comment>Bookmark details dialog, Phonetic search type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_SearchType_PhoneticSearch" xml:space="preserve">
     <value>Phonetic search</value>
-    <comment>Bookmark details dialog, search type Phonetic tooltip</comment>
+    <comment>Bookmark details dialog, Phonetic search type tooltip</comment>
   </data>
   <data name="BookmarkDetails_SearchType_PlainTextSearch" xml:space="preserve">
     <value>Plain text search</value>
-    <comment>Bookmark details dialog, search type Text tooltip</comment>
+    <comment>Bookmark details dialog, Text search type tooltip</comment>
   </data>
   <data name="BookmarkDetails_SearchType_ReadFileAsBinaryAndSearchForBytes" xml:space="preserve">
-    <value>Read file as binary and search for bytes as hexadecimal digits: 68 65 78 20</value>
-    <comment>Bookmark details dialog, search type Hex tooltip</comment>
+    <value>Byte search: read file as binary and search for bytes as hexadecimal digits: 68 65 78 20</value>
+    <comment>Bookmark details dialog, Byte search type tooltip</comment>
   </data>
   <data name="BookmarkDetails_SearchType_Regex" xml:space="preserve">
-    <value>_Regex</value>
+    <value>_Regular expression</value>
     <comment>Bookmark details dialog, search type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_SearchType_RegularExpressionSearch" xml:space="preserve">
     <value>Regular expression search</value>
-    <comment>Bookmark details dialog, search type Regex tooltip</comment>
+    <comment>Bookmark details dialog, search type regular expression tooltip</comment>
   </data>
   <data name="BookmarkDetails_SearchType_Text" xml:space="preserve">
     <value>_Text</value>
@@ -496,7 +496,7 @@ Arguments:
 /pt [type]
 -pt [type]
 -patternType [type]
-    Sets the type of match and ignore pattern – must be one of: "Asterisk", "Regex", or "Everything" (if the Everything search tool is installed).
+    Sets the type of match and ignore pattern – must be one of: "Asterisk" (wildcard), "Regex" (regular expression), or "Everything" (if the Everything search tool is installed).
 
 /s [searchFor]
 -s [searchFor]
@@ -506,7 +506,7 @@ Arguments:
 /st [type]
 -st [type]
 -searchType [type]
-    Sets the type of search – must be one of: "PlainText", "Regex", "XPath", or "Soundex".
+    Sets the type of search – must be one of: "PlainText", "Regex" (regular expression), "XPath", or "Soundex" (phonetic).
 
 /cs [True/False]
 -cs [True/False]
@@ -762,12 +762,12 @@ Arguments:
     <comment>Main window, filter files checkbox label (accel)</comment>
   </data>
   <data name="Main_ForExampleAsteriskPattern" xml:space="preserve">
-    <value>e.g. file??.*</value>
-    <comment>Main window, pattern type option Asterisk tooltip</comment>
+    <value>For example: *.txt;*.xml</value>
+    <comment>Main window, Wildcard pattern type option tooltip</comment>
   </data>
   <data name="Main_ForExampleRegularExpession" xml:space="preserve">
-    <value>e.g. file[0-9]{1,2}\\.txt</value>
-    <comment>Main window, pattern type option Regex tooltip</comment>
+    <value>For example: file[0-9]{1,2}\\.txt</value>
+    <comment>Main window, Regular expression pattern type option tooltip</comment>
   </data>
   <data name="Main_FromTheStartOfTheDay" xml:space="preserve">
     <value>from the start of the day</value>
@@ -874,7 +874,7 @@ Arguments:
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_Save_TextResults" xml:space="preserve">
-    <value>Text Results</value>
+    <value>Text results</value>
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_SaveResults" xml:space="preserve">
@@ -902,16 +902,16 @@ Arguments:
     <comment>Main window, Patterns to match label (accel)</comment>
   </data>
   <data name="Main_PatternType_Asterisk" xml:space="preserve">
-    <value>Asterisk pattern</value>
-    <comment>Main window, pattern type radio button label (accel)</comment>
+    <value>Wildcard</value>
+    <comment>Main window, Wildcard pattern type radio button label (accel)</comment>
   </data>
   <data name="Main_PatternType_Everything" xml:space="preserve">
     <value>Everything</value>
-    <comment>Main window, pattern type radio button label (accel)</comment>
+    <comment>Main window, Everything pattern type radio button label (accel)</comment>
   </data>
   <data name="Main_PatternType_Regex" xml:space="preserve">
-    <value>_Regex</value>
-    <comment>Main window, pattern type radio button label (accel)</comment>
+    <value>_Regular expression</value>
+    <comment>Main window, Regular expression pattern type radio button label (accel)</comment>
   </data>
   <data name="Main_PreviewFile" xml:space="preserve">
     <value>Pre_view file</value>
@@ -930,7 +930,7 @@ Arguments:
     <comment>Main window, replace text input box label (accel)</comment>
   </data>
   <data name="Main_ReportOption_CSVFileFormat" xml:space="preserve">
-    <value>CSV (comma delimited)</value>
+    <value>CSV (comma separated)</value>
     <comment>Main window, save report, report type format label</comment>
   </data>
   <data name="Main_ReportOption_ReportFileFormat" xml:space="preserve">
@@ -1078,48 +1078,48 @@ Arguments:
     <comment>Main window, search options checkbox label (accel)</comment>
   </data>
   <data name="Main_SearchParallel" xml:space="preserve">
-    <value>Search Paralle_l</value>
+    <value>Search paralle_l</value>
     <comment>Main window, search option checkbox label (accel)</comment>
   </data>
   <data name="Main_SearchType_Hex" xml:space="preserve">
-    <value>Hex</value>
-    <comment>Main window, search type radio button label (accel)</comment>
+    <value>Byte</value>
+    <comment>Main window, Byte search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_Phonetic" xml:space="preserve">
     <value>Phonetic</value>
-    <comment>Main window, search type radio button label (accel)</comment>
+    <comment>Main window, Phonetic search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_PhoneticSearch" xml:space="preserve">
     <value>Phonetic search</value>
-    <comment>Main window, search type Phonetic tooltip</comment>
+    <comment>Main window, Phonetic search type tooltip</comment>
   </data>
   <data name="Main_SearchType_PlainTextSearch" xml:space="preserve">
     <value>Plain text search</value>
-    <comment>Main window, search type Text tooltip</comment>
+    <comment>Main window, Text search type tooltip</comment>
   </data>
   <data name="Main_SearchType_ReadFileAsBinaryAndSearchForBytes" xml:space="preserve">
-    <value>Read file as binary and search for bytes as hexadecimal digits: 68 65 78 20</value>
-    <comment>Main window, search type Hex tooltip</comment>
+    <value>Byte search: read file as binary and search for bytes as hexadecimal digits: 68 65 78 20</value>
+    <comment>Main window, Byte search type tooltip</comment>
   </data>
   <data name="Main_SearchType_Regex" xml:space="preserve">
-    <value>_Regex</value>
-    <comment>Main window, search type radio button label (accel)</comment>
+    <value>_Regular expression</value>
+    <comment>Main window, Regular expression search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_RegularExpressionSearch" xml:space="preserve">
-    <value>Search using regular expressions</value>
-    <comment>Main window, search type Regex tooltip</comment>
+    <value>Regular expression search</value>
+    <comment>Main window, Regular expression search type tooltip</comment>
   </data>
   <data name="Main_SearchType_Text" xml:space="preserve">
     <value>_Text</value>
-    <comment>Main window, search type radio button label (accel)</comment>
+    <comment>Main window, Text search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_XPath" xml:space="preserve">
     <value>_XPath</value>
-    <comment>Main window, search type radio button label (accel)</comment>
+    <comment>Main window, XPath search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_XPathSearchXMLDocumentsOnly" xml:space="preserve">
     <value>XPath search (only for XML documents)</value>
-    <comment>Main window, search type XPath tooltip</comment>
+    <comment>Main window, XPath search type tooltip</comment>
   </data>
   <data name="Main_SelectADate" xml:space="preserve">
     <value>Select a date</value>
@@ -1190,7 +1190,7 @@ Arguments:
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_ReplaceComplete0FilesReplaced" xml:space="preserve">
-    <value>Replace complete – replaced text in {0} files.</value>
+    <value>Replace completed – replaced text in {0} files.</value>
     <comment>Main window, status bar message: {0} is the number of files modified by the replace operation</comment>
   </data>
   <data name="Main_Status_ReplaceFailed" xml:space="preserve">
@@ -1210,7 +1210,7 @@ Arguments:
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_SearchCompleteSearched0FilesFound1FilesIn2" xml:space="preserve">
-    <value>Search Complete – searched {0} files, found {1} files in {2}.</value>
+    <value>Search completed – searched {0} files, found {1} files in {2}.</value>
     <comment>Main window, status bar message: {0} is the number of file searched; {1} is the number of files with matches found; {2} is the duration of the search</comment>
   </data>
   <data name="Main_Status_Searched0FilesFound1MatchingFiles" xml:space="preserve">
@@ -1254,19 +1254,19 @@ Arguments:
     <comment>Main window, search option checkbox tooltip</comment>
   </data>
   <data name="Main_Validation_HexStringIsNotValid" xml:space="preserve">
-    <value>Hex string is not valid!</value>
+    <value>Byte string is not valid!</value>
     <comment>Main window, hexadecimal expression status</comment>
   </data>
   <data name="Main_Validation_HexStringIsOK" xml:space="preserve">
-    <value>Hex string is OK</value>
+    <value>Byte string is OK</value>
     <comment>Main window, hexadecimal expression status</comment>
   </data>
   <data name="Main_Validation_RegexIsNotValid" xml:space="preserve">
-    <value>Regex is not valid!</value>
+    <value>Regular expression is not valid!</value>
     <comment>Main window, regular expression status</comment>
   </data>
   <data name="Main_Validation_RegexIsOK" xml:space="preserve">
-    <value>Regex is OK</value>
+    <value>Regular expression is OK</value>
     <comment>Main window, regular expression status</comment>
   </data>
   <data name="Main_Validation_XPathIsNotValid" xml:space="preserve">
@@ -1390,7 +1390,7 @@ Arguments:
     <comment>Message box title for: Move files</comment>
   </data>
   <data name="MessageBox_NewVersion" xml:space="preserve">
-    <value>New version</value>
+    <value>New Version</value>
     <comment>Message box title for: New dnGrep version</comment>
   </data>
   <data name="MessageBox_NewVersionOfDnGREP0IsAvailableForDownload" xml:space="preserve">
@@ -1463,7 +1463,7 @@ Arguments:
   </data>
   <data name="MessageBox_TheFilePattern0IsNotAValidRegularExpression12" xml:space="preserve">
     <value>The file pattern '{0}' is not a valid regular expression:{1}{2}</value>
-    <comment>Message box text for: Main window regex file pattern error: {0} is the invalid regular expression; {1} is a newline; {2} is the reason the expression is invalid</comment>
+    <comment>Message box text for: Main window regular expression file pattern error: {0} is the invalid regular expression; {1} is a newline; {2} is the reason the expression is invalid</comment>
   </data>
   <data name="MessageBox_TheFollowingPluginsFailedToLoad" xml:space="preserve">
     <value>Could not load the following plug-ins:</value>
@@ -1550,7 +1550,7 @@ Arguments:
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_ApplicationFonts" xml:space="preserve">
-    <value>Application Fonts</value>
+    <value>Application fonts</value>
     <comment>Options dialog, Application fonts group header label</comment>
   </data>
   <data name="Options_ArchiveAdd" xml:space="preserve">
@@ -1674,7 +1674,7 @@ Arguments:
     <comment>Options dialog, language request label</comment>
   </data>
   <data name="Options_HexSearchResultLineLength" xml:space="preserve">
-    <value>Hex search result line length</value>
+    <value>Byte search result line length</value>
     <comment>Options dialog, results options combo box label</comment>
   </data>
   <data name="Options_HistoryLists" xml:space="preserve">
@@ -1723,7 +1723,7 @@ Arguments:
   </data>
   <data name="Options_MatchTimeout" xml:space="preserve">
     <value>Match timeout</value>
-    <comment>Options dialog, regex options text input label</comment>
+    <comment>Options dialog, regular expression options text input label</comment>
   </data>
   <data name="Options_OnMainPanel" xml:space="preserve">
     <value>on the main panel</value>
@@ -1734,7 +1734,7 @@ Arguments:
     <comment>Options dialog, window title</comment>
   </data>
   <data name="Options_PDFToText" xml:space="preserve">
-    <value>PDF to Text</value>
+    <value>PDF to text</value>
     <comment>Options dialog, PDF to text group header label</comment>
   </data>
   <data name="Options_PdfToTextExeCommandLineOptions" xml:space="preserve">
@@ -1783,7 +1783,7 @@ Arguments:
   </data>
   <data name="Options_RegexOptions" xml:space="preserve">
     <value>Regular expressions</value>
-    <comment>Options dialog, Regular expressions group heading label</comment>
+    <comment>Options dialog, regular expressions group heading label</comment>
   </data>
   <data name="Options_Reload" xml:space="preserve">
     <value>Reload</value>
@@ -1806,7 +1806,7 @@ Arguments:
     <comment>Options dialog, Search results group header label</comment>
   </data>
   <data name="Options_SampleText" xml:space="preserve">
-    <value>Sample Text</value>
+    <value>Sample text</value>
     <comment>Options dialog, font family and size sample text </comment>
   </data>
   <data name="Options_Save" xml:space="preserve">
@@ -1851,7 +1851,7 @@ Arguments:
   </data>
   <data name="Options_TheMatchTimeoutLimits" xml:space="preserve">
     <value>The match timeout limits how long the regular expression engine attempts to resolve a regular expression before it times out. It prevents processing expressions and input strings requiring excessive backtracking.</value>
-    <comment>Options dialog, regex options help text</comment>
+    <comment>Options dialog, regular expression options help text</comment>
   </data>
   <data name="Options_Theme" xml:space="preserve">
     <value>Theme</value>
@@ -1859,14 +1859,14 @@ Arguments:
   </data>
   <data name="Options_TimeoutSeconds" xml:space="preserve">
     <value>seconds</value>
-    <comment>Options dialog, regex options timeout input label</comment>
+    <comment>Options dialog, regular expression options timeout input label</comment>
   </data>
   <data name="Options_ToChangeThisSettingRunDnGREPAsAdministrator" xml:space="preserve">
     <value>Run dnGrep as Administrator to change this setting.</value>
     <comment>Options dialog, Explorer right-click tooltip</comment>
   </data>
   <data name="Options_UseDefault" xml:space="preserve">
-    <value>Use Default</value>
+    <value>Use default font</value>
     <comment>Options dialog, fonts default checkbox label (accel)</comment>
   </data>
   <data name="Options_WantADifferentLanguage" xml:space="preserve">
@@ -2099,7 +2099,7 @@ Arguments:
   </data>
   <data name="Report_CSVRecordHeaderText" xml:space="preserve">
     <value>File Name,Line Number,String</value>
-    <comment>Report, CSV report header text</comment>
+    <comment>Report, CSV report - these are the column headers in the generated CSV file</comment>
   </data>
   <data name="Report_DnGrepSearchResults" xml:space="preserve">
     <value>dnGrep Search Results</value>
@@ -2214,7 +2214,7 @@ Arguments:
     <comment>Report search options summary</comment>
   </data>
   <data name="ReportSummary_UsingRegexFilePattern" xml:space="preserve">
-    <value>Using regex file pattern</value>
+    <value>Using regular expression file pattern</value>
     <comment>Report search options summary</comment>
   </data>
   <data name="ReportSummary_UsingTypeOfSeach" xml:space="preserve">
@@ -2290,7 +2290,7 @@ Arguments:
     <comment>Test window, search type radio button label (accel)</comment>
   </data>
   <data name="Test_SearchType_Regex" xml:space="preserve">
-    <value>_Regex</value>
+    <value>_Regular expression</value>
     <comment>Test window, search type radio button label (accel)</comment>
   </data>
   <data name="Test_SearchType_Text" xml:space="preserve">
@@ -2334,11 +2334,11 @@ Arguments:
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTA7_ForMoreRegexPatternsHitF1" xml:space="preserve">
-    <value>Hit F1 for more regex patterns</value>
+    <value>Hit F1 for more regular expression patterns</value>
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTB1_ReplacesEntireRegex" xml:space="preserve">
-    <value>$&amp; replaces entire regex</value>
+    <value>$&amp; replaces entire regular expression</value>
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTB2_InsertsTheTextMatchedIntoTheReplacementText" xml:space="preserve">

--- a/dnGREP.Localization/Properties/Resources.resx
+++ b/dnGREP.Localization/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="About_AboutDnGREP" xml:space="preserve">
-    <value>About dnGREP</value>
+    <value>About dnGrep</value>
     <comment>About dialog window title</comment>
   </data>
   <data name="About_Acknowledgments" xml:space="preserve">
@@ -134,7 +134,7 @@
     <comment>About dnGrep acknowledgments</comment>
   </data>
   <data name="About_DnGREP" xml:space="preserve">
-    <value>dnGREP</value>
+    <value>dnGrep</value>
     <comment>About dialog text</comment>
   </data>
   <data name="About_DnGrepOnGitHub" xml:space="preserve">
@@ -146,7 +146,7 @@
     <comment>About dialog acknowledgments</comment>
   </data>
   <data name="About_JsonFrameworkForNET" xml:space="preserve">
-    <value>Json framework for .NET</value>
+    <value>JSON framework for .NET</value>
     <comment>About dialog acknowledgments</comment>
   </data>
   <data name="About_LibraryForReadingArchiveFiles" xml:space="preserve">
@@ -198,7 +198,7 @@
     <comment>About dialog label</comment>
   </data>
   <data name="BookmarkDetails_AssociatedFolders" xml:space="preserve">
-    <value>Associated Folders:</value>
+    <value>Associated folders:</value>
     <comment>Bookmark details dialog, text input box label</comment>
   </data>
   <data name="BookmarkDetails_BooleanOperators" xml:space="preserve">
@@ -226,11 +226,11 @@
     <comment>Bookmark details dialog, search options encoding combo box label (accel) </comment>
   </data>
   <data name="BookmarkDetails_EverythingIndexService" xml:space="preserve">
-    <value>Everything Index Service</value>
+    <value>Everything index service</value>
     <comment>Bookmark details dialog, pattern type option Everything tooltip</comment>
   </data>
   <data name="BookmarkDetails_FilePatternType" xml:space="preserve">
-    <value>File Pattern Type</value>
+    <value>File pattern type</value>
     <comment>Bookmark details dialog, file pattern group header label</comment>
   </data>
   <data name="BookmarkDetails_FollowSymbolicLinks" xml:space="preserve">
@@ -249,7 +249,7 @@
     <value>Include binary files</value>
     <comment>Bookmark details dialog, filter files checkbox label (accel)</comment>
   </data>
-  <data name="BookmarkDetails_IncludeHiddenFolders" xml:space="preserve">
+  <data name="BookmarkDetails_IncludeHiddenFolders" xml:space="preserve">    
     <value>Include hidden folders</value>
     <comment>Bookmark details dialog, filter files checkbox label (accel)</comment>
   </data>
@@ -338,7 +338,7 @@
     <comment>Bookmark details dialog, search type radio button label (accel)</comment>
   </data>
   <data name="BookmarkDetails_SearchType_XPathSearchXMLDocumentsOnly" xml:space="preserve">
-    <value>XPath search (XML documents only)</value>
+    <value>XPath search (only for XML documents)</value>
     <comment>Bookmark details dialog, search type XPath tooltip</comment>
   </data>
   <data name="BookmarkDetails_ThisBookmarkAlreadyExists" xml:space="preserve">
@@ -350,8 +350,8 @@
     <comment>Bookmark details dialog, window title</comment>
   </data>
   <data name="BookmarkDetails_TypeHeader" xml:space="preserve">
-    <value>Type</value>
-    <comment>Bookmark details dialog, type group header label</comment>
+    <value>Search type</value>
+    <comment>Bookmark details dialog, search type group header label</comment>
   </data>
   <data name="BookmarkDetails_UseGitignore" xml:space="preserve">
     <value>Use .gitignore</value>
@@ -390,7 +390,7 @@
     <comment>Bookmarks dialog, button label (accel)</comment>
   </data>
   <data name="Bookmarks_FilePatternHeader" xml:space="preserve">
-    <value>File Pattern</value>
+    <value>File pattern</value>
     <comment>Bookmarks dialog, grid header</comment>
   </data>
   <data name="Bookmarks_Filter" xml:space="preserve">
@@ -398,15 +398,15 @@
     <comment>Bookmarks dialog, filter input box label</comment>
   </data>
   <data name="Bookmarks_OtherPropertiesHeader" xml:space="preserve">
-    <value>Other Properties</value>
+    <value>Other properties</value>
     <comment>Bookmarks dialog, grid header</comment>
   </data>
   <data name="Bookmarks_ReplaceWithHeader" xml:space="preserve">
-    <value>Replace With</value>
+    <value>Replace with</value>
     <comment>Bookmarks dialog, grid header</comment>
   </data>
   <data name="Bookmarks_SearchForHeader" xml:space="preserve">
-    <value>Search For</value>
+    <value>Search for</value>
     <comment>Bookmarks dialog, grid header</comment>
   </data>
   <data name="Bookmarks_Summary_CaseSensitive" xml:space="preserve">
@@ -414,7 +414,7 @@
     <comment>Bookmarks dialog, Other Properties summary</comment>
   </data>
   <data name="Bookmarks_Summary_MaxFolderDepth" xml:space="preserve">
-    <value>Max folder depth {0}</value>
+    <value>Max folder depth: {0}</value>
     <comment>Bookmarks dialog, Other Properties summary: {0} is a number</comment>
   </data>
   <data name="Bookmarks_Summary_Multiline" xml:space="preserve">
@@ -434,7 +434,7 @@
     <comment>Bookmarks dialog, Other Properties summary</comment>
   </data>
   <data name="Bookmarks_Summary_NoSymlinks" xml:space="preserve">
-    <value>No symlinks</value>
+    <value>No symbolic links</value>
     <comment>Bookmarks dialog, Other Properties summary</comment>
   </data>
   <data name="Bookmarks_Summary_SearchInArchives" xml:space="preserve">
@@ -481,22 +481,22 @@ Arguments:
 /f [folderPath]
 -f [folderPath]
 -folder [folderPath]
-    Sets the folder path to search.  May be a comma or semi-colon separated list of folder paths.
+    Sets the folder path to search.  May be a comma- or semicolon-separated list of folder paths.
 
 /pm [pattern]
 -pm [pattern]
 -pathToMatch [pattern]
-    Sets the file name pattern to match files in the search path. May be a comma or semi-colon separated list of patterns.
+    Sets the file name pattern to match files in the search path. May be a comma- or semicolon-separated list of patterns.
 
 /pi [pattern]
 -pi [pattern]
 -pathToIgnore [pattern]
-    Sets the file or directory name pattern to exclude files or folders in the search path. May be a comma or semi-colon separated list of patterns.
+    Sets the file or directory name pattern to exclude files or folders in the search path. May be a comma- or semicolon-separated list of patterns.
 
 /pt [type]
 -pt [type]
 -patternType [type]
-    Sets the type of match and ignore pattern - must be one of: Asterisk, Regex, or Everything (if the Everything search tool is installed).
+    Sets the type of match and ignore pattern – must be one of: "Asterisk", "Regex", or "Everything" (if the Everything search tool is installed).
 
 /s [searchFor]
 -s [searchFor]
@@ -506,32 +506,32 @@ Arguments:
 /st [type]
 -st [type]
 -searchType [type]
-    Sets the type of search - must be one of: PlainText, Regex, XPath, or Soundex.
+    Sets the type of search – must be one of: "PlainText", "Regex", "XPath", or "Soundex".
 
 /cs [True/False]
 -cs [True/False]
 -caseSensitive [True/False]
-    Sets case sensitive search flag - True or False.
+    Sets case-sensitive search flag – True or False.
 
 /ww [True/False]
 -ww [True/False]
 -wholeWord [True/False]
-    Sets the whole word search flag - True or False.
+    Sets the whole word search flag – True or False.
 
 /ml [True/False]
 -ml [True/False]
 -multiline [True/False]
-    Sets the multiline search flag - True or False.
+    Sets the multiline search flag – True or False.
 
 /dn [True/False]
 -dn [True/False]
 -dotAsNewline [True/False]
-    Sets the dot as newline search flag - True or False.
+    Sets the dot as newline search flag – True or False.
 
 /bo [True/False]
 -bo [True/False]
 -booleanOperators [True/False]
-    Sets the Boolean operators search flag - True or False.
+    Sets the Boolean operators search flag – True or False.
 
 /rpt [filePath]
 -rpt [filePath]
@@ -550,8 +550,8 @@ Arguments:
 /x
 -x
 -exit
-    Exit dnGrep after command line operations are complete.</value>
-    <comment>Help dialog text when running dnGrep from the command line: {0} is the installed dnGrep version number; {1} is the installed dnGrep build date</comment>
+    Exit dnGrep after command-line operations are complete.</value>
+    <comment>Help dialog text when running dnGrep from the command-line: {0} is the installed dnGrep version number; {1} is the installed dnGrep build date</comment>
   </data>
   <data name="Help_DnGrepHelp" xml:space="preserve">
     <value>dnGrep Help</value>
@@ -562,7 +562,7 @@ Arguments:
     <comment>Help dialog button label</comment>
   </data>
   <data name="Help_OneOrMoreArgumentsAreInvalid" xml:space="preserve">
-    <value>One or more arguments are invalid.</value>
+    <value>One or more arguments are not valid.</value>
     <comment>Help dialog header text</comment>
   </data>
   <data name="Main_AddSearchPatternToBookmarks" xml:space="preserve">
@@ -582,7 +582,7 @@ Arguments:
     <comment>Main window, folder bookmark button tooltip</comment>
   </data>
   <data name="Main_Attributes_DateModified" xml:space="preserve">
-    <value>Date Modified:</value>
+    <value>Date modified:</value>
     <comment>Main window, results list, file attributes tooltip label</comment>
   </data>
   <data name="Main_Attributes_Encoding" xml:space="preserve">
@@ -602,7 +602,7 @@ Arguments:
     <comment>Main window, results list, file attributes tooltip label</comment>
   </data>
   <data name="Main_AutoPosition" xml:space="preserve">
-    <value>Auto Position</value>
+    <value>Auto position</value>
     <comment>Main window, docking context menu item label (accel)</comment>
   </data>
   <data name="Main_BooleanOperators" xml:space="preserve">
@@ -626,7 +626,7 @@ Arguments:
     <comment>Main window, search option checkbox label (accel)</comment>
   </data>
   <data name="Main_ChangesTheResultsTreeZoom" xml:space="preserve">
-    <value>Changes the results tree zoom</value>
+    <value>Changes the zoom level of the results tree</value>
     <comment>Main window tooltip</comment>
   </data>
   <data name="Main_ClearBookmark" xml:space="preserve">
@@ -646,7 +646,7 @@ Arguments:
     <comment>Main window, results options context lines label</comment>
   </data>
   <data name="Main_ContextChangesWillBeAppliedInNextSearch" xml:space="preserve">
-    <value>Context changes Will be applied in next search</value>
+    <value>Context line changes will be applied in next search</value>
     <comment>Main window, result options context lines tooltip</comment>
   </data>
   <data name="Main_ContextShowLines" xml:space="preserve">
@@ -674,15 +674,15 @@ Arguments:
     <comment>Main window, filter files by date label</comment>
   </data>
   <data name="Main_DnGREP_Title" xml:space="preserve">
-    <value>dnGREP</value>
-    <comment>Main window, title label - near menu bar</comment>
+    <value>dnGrep</value>
+    <comment>Main window, title label – near menu bar</comment>
   </data>
   <data name="Main_DockBottom" xml:space="preserve">
-    <value>Dock Bottom</value>
+    <value>Dock bottom</value>
     <comment>Main window docking context menu item label (accel)</comment>
   </data>
   <data name="Main_DockRight" xml:space="preserve">
-    <value>Dock Right</value>
+    <value>Dock right</value>
     <comment>Main window docking context menu label (accel)</comment>
   </data>
   <data name="Main_DotAsNewline" xml:space="preserve">
@@ -702,7 +702,7 @@ Arguments:
     <comment>Main window encoding auto select text</comment>
   </data>
   <data name="Main_EverythingIndexService" xml:space="preserve">
-    <value>Everything Index Service</value>
+    <value>Everything index service</value>
     <comment>Main window, pattern type option Everything tooltip</comment>
   </data>
   <data name="Main_EverythingSearch" xml:space="preserve">
@@ -722,19 +722,19 @@ Arguments:
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_FilterSummary_ByCreatedDate" xml:space="preserve">
-    <value>By Created Date</value>
+    <value>By created date</value>
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_FilterSummary_ByModifiedDate" xml:space="preserve">
-    <value>By Modified Date</value>
+    <value>By modified date</value>
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_FilterSummary_BySize" xml:space="preserve">
-    <value>By Size</value>
+    <value>By size</value>
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_FilterSummary_MaxFolderDepth" xml:space="preserve">
-    <value>Max folder depth {0}</value>
+    <value>Max folder depth: {0}</value>
     <comment>Main window, file filters summary: {0} is a number</comment>
   </data>
   <data name="Main_FilterSummary_NoBinary" xml:space="preserve">
@@ -750,7 +750,7 @@ Arguments:
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_FilterSummary_NoSymlinks" xml:space="preserve">
-    <value>No symlinks</value>
+    <value>No symbolic links</value>
     <comment>Main window, file filters summary</comment>
   </data>
   <data name="Main_Folder" xml:space="preserve">
@@ -778,15 +778,15 @@ Arguments:
     <comment>Main window, result options expander button tooltip (bottom of window)</comment>
   </data>
   <data name="Main_HighlightGroups" xml:space="preserve">
-    <value>Highlight Groups</value>
+    <value>Highlight groups</value>
     <comment>Main window, results options checkbox label (accel)</comment>
   </data>
   <data name="Main_HighlightMatches" xml:space="preserve">
-    <value>Highlight Matches</value>
+    <value>Highlight matches</value>
     <comment>Main window, results options checkbox label (accel)</comment>
   </data>
   <data name="Main_HighlightRegularExpressionGroups" xml:space="preserve">
-    <value>Highlight regular expression groups - changes will be applied in next search</value>
+    <value>Highlight regular expression groups. Changes will be applied in next search.</value>
     <comment>Main window, result options highlight groups tooltip</comment>
   </data>
   <data name="Main_IncludeBinaryFiles" xml:space="preserve">
@@ -814,7 +814,7 @@ Arguments:
     <comment>Main window, main menu label (accel)</comment>
   </data>
   <data name="Main_Menu_About_AboutDnGrep" xml:space="preserve">
-    <value>_About dnGrep...</value>
+    <value>_About dnGrep…</value>
     <comment>Main window, main menu subitem label (accel)</comment>
   </data>
   <data name="Main_Menu_About_Help" xml:space="preserve">
@@ -822,11 +822,11 @@ Arguments:
     <comment>Main window, main menu subitem label (accel)</comment>
   </data>
   <data name="Main_Menu_Bookmarks" xml:space="preserve">
-    <value>_Bookmarks...</value>
+    <value>_Bookmarks…</value>
     <comment>Main window, main menu item label (accel)</comment>
   </data>
   <data name="Main_Menu_Options" xml:space="preserve">
-    <value>_Options...</value>
+    <value>_Options…</value>
     <comment>Main window, main menu item label (accel)</comment>
   </data>
   <data name="Main_Menu_Undo" xml:space="preserve">
@@ -838,7 +838,7 @@ Arguments:
     <comment>Main window, filter files by date radio button label (accel)</comment>
   </data>
   <data name="Main_More" xml:space="preserve">
-    <value>Mor_e...</value>
+    <value>Mor_e…</value>
     <comment>Main window, filters expander label (accel)</comment>
   </data>
   <data name="Main_MoreArrowButton" xml:space="preserve">
@@ -850,7 +850,7 @@ Arguments:
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_CopyFiles" xml:space="preserve">
-    <value>Copy files...</value>
+    <value>Copy files…</value>
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_CopyResults" xml:space="preserve">
@@ -858,15 +858,15 @@ Arguments:
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_DeleteFiles" xml:space="preserve">
-    <value>Delete files...</value>
+    <value>Delete files…</value>
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_MoveFiles" xml:space="preserve">
-    <value>Move files...</value>
+    <value>Move files…</value>
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_Save_CSVResults" xml:space="preserve">
-    <value>CSV Results</value>
+    <value>CSV results</value>
     <comment>Main window, More button menu item label (accel)</comment>
   </data>
   <data name="Main_MoreMenu_Save_Report" xml:space="preserve">
@@ -886,7 +886,7 @@ Arguments:
     <comment>Main window, search option checkbox label (accel)</comment>
   </data>
   <data name="Main_OpenFolder" xml:space="preserve">
-    <value>...</value>
+    <value>…</value>
     <comment>Main window, open folder button label (accel)</comment>
   </data>
   <data name="Main_PastDateTo" xml:space="preserve">
@@ -930,19 +930,19 @@ Arguments:
     <comment>Main window, replace text input box label (accel)</comment>
   </data>
   <data name="Main_ReportOption_CSVFileFormat" xml:space="preserve">
-    <value>CSV file format</value>
+    <value>CSV (comma delimited)</value>
     <comment>Main window, save report, report type format label</comment>
   </data>
   <data name="Main_ReportOption_ReportFileFormat" xml:space="preserve">
-    <value>Report file format</value>
+    <value>Report format</value>
     <comment>Main window, save report, report type format label</comment>
   </data>
   <data name="Main_ReportOption_ResultsFileFormat" xml:space="preserve">
-    <value>Results file format</value>
+    <value>Text file</value>
     <comment>Main window, save report, report type format label</comment>
   </data>
   <data name="Main_ResetOptions" xml:space="preserve">
-    <value>Reset Options</value>
+    <value>Reset filters</value>
     <comment>Main window, search options, reset button label (accel)</comment>
   </data>
   <data name="Main_ResultList_AdditionalMatches" xml:space="preserve">
@@ -950,7 +950,7 @@ Arguments:
     <comment>Main window, search results text</comment>
   </data>
   <data name="Main_ResultList_AtEndOfLine" xml:space="preserve">
-    <value>(at end of line)</value>
+    <value>(at end of the line)</value>
     <comment>Main window, search results text</comment>
   </data>
   <data name="Main_ResultList_AtPosition" xml:space="preserve">
@@ -958,7 +958,7 @@ Arguments:
     <comment>Main window, search results text: {0} is number, the offset from the start of the line</comment>
   </data>
   <data name="Main_ResultList_CountAdditionalCharacters" xml:space="preserve">
-    <value>...(+{0:n0} characters)</value>
+    <value>…(+{0:n0} characters)</value>
     <comment>Main window, search results text</comment>
   </data>
   <data name="Main_ResultList_CountMatches" xml:space="preserve">
@@ -971,11 +971,10 @@ Arguments:
   </data>
   <data name="Main_ResultList_MatchToolTip1" xml:space="preserve">
     <value>Match {0}{1}{2}</value>
-    
     <comment>Main window results, capture group tooltip: {0} is the match index; {1} is a new line; {2} is text of in the group</comment>
   </data>
   <data name="Main_ResultList_MatchToolTip2" xml:space="preserve">
-    <value>Match {0}{1}Group {2}:   {3}</value>
+    <value>Match {0}{1}Group {2}: {3}</value>
     <comment>Main window results, capture group tooltip: {0} is the match index; {1} is a new line; {2} is the named group name; {3} is the text in the group</comment>
   </data>
   <data name="Main_ResultList_PlusCountMoreMatches" xml:space="preserve">
@@ -1003,7 +1002,7 @@ Arguments:
     <comment>Main window, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_CopyLinesOfText" xml:space="preserve">
-    <value>Copy Lines of text</value>
+    <value>Copy lines of text</value>
     <comment>Main window, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_ExcludeFromResults" xml:space="preserve">
@@ -1015,7 +1014,7 @@ Arguments:
     <comment>Main window, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_NextMatch" xml:space="preserve">
-    <value>Next Match</value>
+    <value>Next match</value>
     <comment>Main windows, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_Open" xml:space="preserve">
@@ -1031,7 +1030,7 @@ Arguments:
     <comment>Main window, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_PreviousMatch" xml:space="preserve">
-    <value>Previous Match</value>
+    <value>Previous match</value>
     <comment>Main windows, results list, context menu item label</comment>
   </data>
   <data name="Main_Results_RenameFile" xml:space="preserve">
@@ -1047,7 +1046,7 @@ Arguments:
     <comment>Main window, results list, context menu item label</comment>
   </data>
   <data name="Main_SavingResultsToFile" xml:space="preserve">
-    <value>Saving results to file...</value>
+    <value>Saving results to file…</value>
     <comment>Main window, status message</comment>
   </data>
   <data name="Main_SearchButton" xml:space="preserve">
@@ -1107,7 +1106,7 @@ Arguments:
     <comment>Main window, search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_RegularExpressionSearch" xml:space="preserve">
-    <value>Regular expression search</value>
+    <value>Search using regular expressions</value>
     <comment>Main window, search type Regex tooltip</comment>
   </data>
   <data name="Main_SearchType_Text" xml:space="preserve">
@@ -1119,7 +1118,7 @@ Arguments:
     <comment>Main window, search type radio button label (accel)</comment>
   </data>
   <data name="Main_SearchType_XPathSearchXMLDocumentsOnly" xml:space="preserve">
-    <value>XPath search (XML documents only)</value>
+    <value>XPath search (only for XML documents)</value>
     <comment>Main window, search type XPath tooltip</comment>
   </data>
   <data name="Main_SelectADate" xml:space="preserve">
@@ -1152,78 +1151,78 @@ Arguments:
   </data>
   <data name="Main_SortMenu_Descending" xml:space="preserve">
     <value>Descending</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_FileNameOnly" xml:space="preserve">
     <value>File name only</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_FileSize" xml:space="preserve">
     <value>File size</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_FileTypeAndName" xml:space="preserve">
     <value>File type and name</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_LastWriteTime" xml:space="preserve">
     <value>Last write time</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_MatchCount" xml:space="preserve">
     <value>Match count</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_PathAndFileNameBreadthFirst" xml:space="preserve">
     <value>Path and file name, breadth-first</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_SortMenu_PathAndFileNameDepthFirst" xml:space="preserve">
     <value>Path and file name, depth-first</value>
-    <comment>Main window sort options options menu label (accel)</comment>
+    <comment>Main window sort options menu label (accel)</comment>
   </data>
   <data name="Main_Status_Excluded0MissingFiles" xml:space="preserve">
     <value>Excluded {0} missing files.</value>
     <comment>Main window, status bar message appended on search complete when in Everything mode</comment>
   </data>
   <data name="Main_Status_ReplaceCanceled" xml:space="preserve">
-    <value>Replace Canceled</value>
+    <value>Replace canceled</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_ReplaceComplete0FilesReplaced" xml:space="preserve">
-    <value>Replace Complete - {0} files replaced.</value>
+    <value>Replace complete – replaced text in {0} files.</value>
     <comment>Main window, status bar message: {0} is the number of files modified by the replace operation</comment>
   </data>
   <data name="Main_Status_ReplaceFailed" xml:space="preserve">
-    <value>Replace Failed.</value>
+    <value>Replace failed</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_Replacing" xml:space="preserve">
-    <value>Replacing...</value>
+    <value>Replacing…</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_SearchCanceled" xml:space="preserve">
-    <value>Search Canceled</value>
+    <value>Search canceled</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_SearchCanceledOrFailed" xml:space="preserve">
-    <value>Search Canceled or Failed</value>
+    <value>Search canceled or failed</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_SearchCompleteSearched0FilesFound1FilesIn2" xml:space="preserve">
-    <value>Search Complete - Searched {0} files. Found {1} files in {2}.</value>
+    <value>Search Complete – searched {0} files, found {1} files in {2}.</value>
     <comment>Main window, status bar message: {0} is the number of file searched; {1} is the number of files with matches found; {2} is the duration of the search</comment>
   </data>
   <data name="Main_Status_Searched0FilesFound1MatchingFiles" xml:space="preserve">
-    <value>Searched {0} files. Found {1} matching files.</value>
+    <value>Searched {0} files, found {1} matching files.</value>
     <comment>Main window, status bar message: {0} is the number of file searched; {1} is the number of files with matches found</comment>
   </data>
   <data name="Main_Status_Searched0FilesFound1MatchingFilesProcessing2" xml:space="preserve">
-    <value>Searched {0} files. Found {1} matching files - processing {2}</value>
+    <value>Searched {0} files, found {1} matching files – processing {2}</value>
     <comment>Main window, status bar message: {0} is the number of file searched; {1} is the number of files with matches found; {2} is the current file name being searched</comment>
   </data>
   <data name="Main_Status_Searching" xml:space="preserve">
-    <value>Searching...</value>
+    <value>Searching…</value>
     <comment>Main window, status bar message</comment>
   </data>
   <data name="Main_Status_SearchingForGitignore" xml:space="preserve">
@@ -1235,7 +1234,7 @@ Arguments:
     <comment>Main window, search options checkbox label (accel)</comment>
   </data>
   <data name="Main_TestExpression" xml:space="preserve">
-    <value>Test Expression</value>
+    <value>Test expression</value>
     <comment>Main window, test search expression button label (accel)</comment>
   </data>
   <data name="Main_ThroughTheEndOfTheDay" xml:space="preserve">
@@ -1243,7 +1242,7 @@ Arguments:
     <comment>Main window, filter file by date, end date tooltip</comment>
   </data>
   <data name="Main_UseCaptureGroupsFromPathsToMatch" xml:space="preserve">
-    <value>Use capture groups from 'Paths to match' in the 'Search for' pattern</value>
+    <value>Use capture groups from 'Patterns to match' in the 'Search for' pattern</value>
     <comment>Main window, search option capture group tooltip</comment>
   </data>
   <data name="Main_UseGitignore" xml:space="preserve">
@@ -1259,7 +1258,7 @@ Arguments:
     <comment>Main window, hexadecimal expression status</comment>
   </data>
   <data name="Main_Validation_HexStringIsOK" xml:space="preserve">
-    <value>Hex string is OK!</value>
+    <value>Hex string is OK</value>
     <comment>Main window, hexadecimal expression status</comment>
   </data>
   <data name="Main_Validation_RegexIsNotValid" xml:space="preserve">
@@ -1267,7 +1266,7 @@ Arguments:
     <comment>Main window, regular expression status</comment>
   </data>
   <data name="Main_Validation_RegexIsOK" xml:space="preserve">
-    <value>Regex is OK!</value>
+    <value>Regex is OK</value>
     <comment>Main window, regular expression status</comment>
   </data>
   <data name="Main_Validation_XPathIsNotValid" xml:space="preserve">
@@ -1275,7 +1274,7 @@ Arguments:
     <comment>Main window, XPath status</comment>
   </data>
   <data name="Main_Validation_XPathIsOK" xml:space="preserve">
-    <value>XPath is OK!</value>
+    <value>XPath is OK</value>
     <comment>Main window, XPath status</comment>
   </data>
   <data name="Main_WholeWord" xml:space="preserve">
@@ -1283,11 +1282,11 @@ Arguments:
     <comment>Main window, search option checkbox label (accel)</comment>
   </data>
   <data name="Main_WindowTitle" xml:space="preserve">
-    <value>{0} in "{1}" - dnGREP</value>
+    <value>{0} in "{1}" – dnGrep</value>
     <comment>Main window title: {0} is the current search pattern; {1} is the current search folder</comment>
   </data>
   <data name="Main_WrapText" xml:space="preserve">
-    <value>Wrap Text</value>
+    <value>Wrap text</value>
     <comment>Main window, results options checkbox label (accel)</comment>
   </data>
   <data name="Main_Zoom" xml:space="preserve">
@@ -1295,23 +1294,23 @@ Arguments:
     <comment>Main window, results options zoom slider label</comment>
   </data>
   <data name="MessageBox_AreYouSureYouWantToContinue" xml:space="preserve">
-    <value>Are you sure you want to continue?</value>
+    <value>Continue?</value>
     <comment>Message box text for: Delete files</comment>
   </data>
   <data name="MessageBox_AreYouSureYouWantToReplaceSearchPatternWithEmptyString" xml:space="preserve">
-    <value>Are you sure you want to replace search pattern with empty string?</value>
+    <value>Replace the search pattern with an empty string?</value>
     <comment>Message box text for: Replace text</comment>
   </data>
   <data name="MessageBox_CheckEditorPath" xml:space="preserve">
-    <value>Check editor path via "Options...".</value>
+    <value>Check editor path via "Options…".</value>
     <comment>Message box text for: Open file failed</comment>
   </data>
   <data name="MessageBox_ClearingThisBookmarkWillAlsoClearThatBookmark" xml:space="preserve">
-    <value>Clearing this bookmark will also clear that bookmark.</value>
+    <value>Clearing this bookmark also clears that bookmark.</value>
     <comment>Message box text for: Main window, bookmark button</comment>
   </data>
   <data name="MessageBox_ClearingThisBookmarkWillAlsoRemoveThoseBookmarks" xml:space="preserve">
-    <value>Clearing this bookmark will also remove those bookmarks.</value>
+    <value>Clearing this bookmark also removes those bookmarks.</value>
     <comment>Message box text for: Main window, bookmark button</comment>
   </data>
   <data name="MessageBox_CopyFiles" xml:space="preserve">
@@ -1319,32 +1318,32 @@ Arguments:
     <comment>Message box title for: Copy files</comment>
   </data>
   <data name="MessageBox_CouldNotLoadResourcesFile0" xml:space="preserve">
-    <value>Could not load resources file '{0}': </value>
+    <value>Could not load the '{0}' resources file: </value>
     <comment>Message box text for: Load language resource: {0} is the name of the file that failed to load</comment>
   </data>
   <data name="MessageBox_CouldNotLoadTheme" xml:space="preserve">
-    <value>Could not load theme '{0}', See the error log for details: </value>
+    <value>Could not load the '{0}' theme. Check the error log for details: </value>
     <comment>Message box text for: Load theme resource: {0} is the name of the file that failed to load</comment>
   </data>
   <data name="MessageBox_CountFilesHaveBeenSuccessfullyCopied" xml:space="preserve">
-    <value>{0} files have been successfully copied.</value>
+    <value>{0} files have been copied.</value>
     <comment>Message box text for: Copy file: {0} is the number of files</comment>
   </data>
   <data name="MessageBox_CountFilesHaveBeenSuccessfullyDeleted" xml:space="preserve">
-    <value>{0} files have been successfully deleted.</value>
+    <value>{0} files have been deleted.</value>
     <comment>Message box text for: Delete files: {0} is the number of files</comment>
   </data>
   <data name="MessageBox_CountFilesHaveBeenSuccessfullyMoved" xml:space="preserve">
-    <value>{0} files have been successfully moved.</value>
+    <value>{0} files have been moved.</value>
     <comment>Message box text for: Move files: {0} is the number of files</comment>
   </data>
   <data name="MessageBox_CustomEditorFileOpenError" xml:space="preserve">
-    <value>There was an error opening file by custom editor.</value>
+    <value>Could not open the file with the custom editor.</value>
     <comment>Message box text for: Open file with custom editor</comment>
   </data>
   <data name="MessageBox_DefaultEngineWasUsedInstead" xml:space="preserve">
-    <value>Default engine was used instead.</value>
-    <comment>Message box text for: Plugin failed to load error</comment>
+    <value>The default engine was used instead.</value>
+    <comment>Message box text for: Plug-in failed to load error</comment>
   </data>
   <data name="MessageBox_DeleteFiles" xml:space="preserve">
     <value>Delete Files</value>
@@ -1355,7 +1354,7 @@ Arguments:
     <comment>Message box title</comment>
   </data>
   <data name="MessageBox_DoYouWantToContinue" xml:space="preserve">
-    <value>Do you want to continue?</value>
+    <value>Continue?</value>
     <comment>Message box text for: Main window, bookmark button</comment>
   </data>
   <data name="MessageBox_Error" xml:space="preserve">
@@ -1363,19 +1362,19 @@ Arguments:
     <comment>Message box text for: general error message</comment>
   </data>
   <data name="MessageBox_ErrorOpeningFile" xml:space="preserve">
-    <value>There was an error opening file. See the error log for details: </value>
+    <value>Could not open the file. Check the error log for details: </value>
     <comment>Message box text for: Open file error</comment>
   </data>
   <data name="MessageBox_ErrorSettingClipboardTextTheClipboardIsLockedBy" xml:space="preserve">
-    <value>Error setting clipboard text, the clipboard is locked by</value>
+    <value>Could not set clipboard text. The clipboard is locked by</value>
     <comment>Message box text for: Copy to clipboard error</comment>
   </data>
   <data name="MessageBox_FailedToExtractFileFromArchive" xml:space="preserve">
-    <value>Failed to extract file from archive. See the error log for details: </value>
+    <value>Could not extract file from archive. Check the error log for details: </value>
     <comment>Message box text for: Preview window archive error</comment>
   </data>
   <data name="MessageBox_FilesHaveBeenSuccessfullyReverted" xml:space="preserve">
-    <value>Files have been successfully reverted.</value>
+    <value>Files have been reverted.</value>
     <comment>Message box text for: Main window undo replace success</comment>
   </data>
   <data name="MessageBox_IncorrectPattern" xml:space="preserve">
@@ -1395,7 +1394,7 @@ Arguments:
     <comment>Message box title for: New dnGrep version</comment>
   </data>
   <data name="MessageBox_NewVersionOfDnGREP0IsAvailableForDownload" xml:space="preserve">
-    <value>New version of dnGREP ({0}) is available for download.</value>
+    <value>New version of dnGrep ({0}) is available for download.</value>
     <comment>Message box text for: New dnGrep version: {0} is the new version number</comment>
   </data>
   <data name="MessageBox_PleaseSelectAnotherDirectoryAndTryAgain" xml:space="preserve">
@@ -1403,11 +1402,11 @@ Arguments:
     <comment>Message box text for: Copy files and Move files (destination overlaps source)</comment>
   </data>
   <data name="MessageBox_PluginErrors" xml:space="preserve">
-    <value>Plugin Errors</value>
-    <comment>Message box title for: Plugin errors</comment>
+    <value>Plug-in Errors</value>
+    <comment>Message box title for: Plug-in errors</comment>
   </data>
   <data name="MessageBox_RenameFailed" xml:space="preserve">
-    <value>Rename failed: </value>
+    <value>Could not rename the file: </value>
     <comment>Message box text for: Rename file</comment>
   </data>
   <data name="MessageBox_RenameFile" xml:space="preserve">
@@ -1419,7 +1418,7 @@ Arguments:
     <comment>Message box text for: Replace message</comment>
   </data>
   <data name="MessageBox_ReplaceFailedError" xml:space="preserve">
-    <value>Replace failed! See the error log for details: </value>
+    <value>Could not replace text in files. Check the error log for details: </value>
     <comment>Message box text for: Replace failed</comment>
   </data>
   <data name="MessageBox_ResourcesFile0IsNotAResxFile" xml:space="preserve">
@@ -1427,23 +1426,23 @@ Arguments:
     <comment>Message box text for: Load language resource file error: {0} is the name of the file that failed to load</comment>
   </data>
   <data name="MessageBox_RunDnGrepAsAdministrator" xml:space="preserve">
-    <value>Run dnGrep as Administrator to change showing dnGrep in Explorer right-click menu</value>
+    <value>Run dnGrep as Administrator to change showing dnGrep in Windows Explorer right-click menu</value>
     <comment>Message box text for: Options dialog, changing Windows integration options</comment>
   </data>
   <data name="MessageBox_RunDnGrepAsAdministratorToChangeStartupRegister" xml:space="preserve">
-    <value>Run dnGrep as Administrator to change Startup Register</value>
+    <value>Run dnGrep as Administrator to change application startup option.</value>
     <comment>Message box text for: Options dialog, changing Windows integration options</comment>
   </data>
   <data name="MessageBox_SearchFailedError" xml:space="preserve">
-    <value>Search failed! See the error log for details: </value>
+    <value>Could not complete the search. Check the error log for details: </value>
     <comment>Message box text for: Search failed</comment>
   </data>
   <data name="MessageBox_SearchOrReplaceFailed" xml:space="preserve">
-    <value>Search or replace failed! See the error log for details: </value>
+    <value>Could not complete the search or replace. Check the error log for details: </value>
     <comment>Message box text for: Search or Replace failed</comment>
   </data>
   <data name="MessageBox_SearchPathInTheFieldIsNotValid" xml:space="preserve">
-    <value>Search path in the '{0}' field is not valid, search canceled.</value>
+    <value>The search path in the '{0}' field is not valid, search canceled.</value>
     <comment>Message box text for: Main window search path invalid: {0} is the name of search path field (Folder or Everything search)</comment>
   </data>
   <data name="MessageBox_SomeOfTheFilesAreLocatedInTheSelectedDirectory" xml:space="preserve">
@@ -1455,71 +1454,71 @@ Arguments:
     <comment>Message box text for: Main window replace warning</comment>
   </data>
   <data name="MessageBox_SomethingBrokeDownInDnGrep" xml:space="preserve">
-    <value>Something broke down in dnGrep. See the error log for details: </value>
+    <value>Something broke down in dnGrep. Check the error log for details: </value>
     <comment>Message box text for: Unknown error</comment>
   </data>
   <data name="MessageBox_TheFile0AlreadyExistsIn1OverwriteExisting" xml:space="preserve">
-    <value>The file '{0}' already exists in {1}, overwrite existing?</value>
-    <comment>Message box text for: Copy or Move files: {0} is a file name; {1} is a folder name</comment>
+    <value>The file '{0}' already exists in {1}. Overwrite existing?</value>
+    <comment>Message box text for: Copy or Move files: {0} is a file name; {1} is the name of a folder</comment>
   </data>
   <data name="MessageBox_TheFilePattern0IsNotAValidRegularExpression12" xml:space="preserve">
     <value>The file pattern '{0}' is not a valid regular expression:{1}{2}</value>
     <comment>Message box text for: Main window regex file pattern error: {0} is the invalid regular expression; {1} is a newline; {2} is the reason the expression is invalid</comment>
   </data>
   <data name="MessageBox_TheFollowingPluginsFailedToLoad" xml:space="preserve">
-    <value>The following plugins failed to load:</value>
-    <comment>Message box text for: plugin load errors</comment>
+    <value>Could not load the following plug-ins:</value>
+    <comment>Message box text for: plug-in load errors</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorAddingDnGrepToExplorerRightClickMenu" xml:space="preserve">
-    <value>There was an error adding dnGrep to Explorer right-click menu. See the error log for details: </value>
+    <value>Could not add dnGrep to the Windows Explorer right-click menu. Check the error log for details: </value>
     <comment>Message box text for: set Explorer context menu error</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorCopyingFiles" xml:space="preserve">
-    <value>There was an error copying files. See the error log for details: </value>
+    <value>Could not copy the files. Check the error log for details: </value>
     <comment>Message box text for: Copy files</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorCreatingTheFile" xml:space="preserve">
-    <value>There was an error creating the file. See the error log for details: </value>
+    <value>Could not create the file. Check the error log for details: </value>
     <comment>Message box text for: Create file</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorDeletingFiles" xml:space="preserve">
-    <value>There was an error deleting files. See the error log for details: </value>
+    <value>Could not delete the files. Check the error log for details: </value>
     <comment>Message box text for: Delete file</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorMovingFiles" xml:space="preserve">
-    <value>There was an error moving files. See the error log for details: </value>
+    <value>Could not move the files. Check the error log for details: </value>
     <comment>Message box text for: Move file</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorRegisteringAutoStartup" xml:space="preserve">
-    <value>There was an error registering auto startup. See the error log for details: </value>
+    <value>Could not register auto startup. Check the error log for details: </value>
     <comment>Message box text for: set startup option error</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorRemovingDnGrepFromTheExplorerRightClickMenu" xml:space="preserve">
-    <value>There was an error removing dnGrep from the Explorer right-click menu. See the error log for details: </value>
+    <value>Could not remove dnGrep from the Windows Explorer right-click menu. Check the error log for details: </value>
     <comment>Message box text for: unset Explorer context menu error</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorRevertingFiles" xml:space="preserve">
-    <value>There was an error reverting files. See the error log for details: </value>
+    <value>Could not revert files. Check the error log for details: </value>
     <comment>Message box text for: Undo replace error</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorRunningRegexTest" xml:space="preserve">
-    <value>There was an error running the test window. See the error log for details: </value>
+    <value>Could not open the test window. Check the error log for details: </value>
     <comment>Message box text for: Main window start test dialog error</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorSavingOptions" xml:space="preserve">
-    <value>There was an error saving options. See the error log for details: </value>
+    <value>Could not save options. Check the error log for details: </value>
     <comment>Message box text for: Saving user options</comment>
   </data>
   <data name="MessageBox_ThereWasAnErrorUnregisteringAutoStartup" xml:space="preserve">
-    <value>There was an error unregistering auto startup. See the error log for details: </value>
+    <value>Could not unregister auto startup. Check the error log for details: </value>
     <comment>Message box text for: unsetting auto start error</comment>
   </data>
   <data name="MessageBox_ThisBookmarkIsAssociatedWith0OtherFolders" xml:space="preserve">
-    <value>This bookmark is associated with {0} other folders:</value>
+    <value>This bookmark is associated with {0} other folders.</value>
     <comment>Message box text for: Main window bookmark delete: {0} is the number of folders</comment>
   </data>
   <data name="MessageBox_ThisBookmarkIsAssociatedWithOneOtherFolder" xml:space="preserve">
-    <value>This bookmark is associated with one other folder</value>
+    <value>This bookmark is associated with one other folder.</value>
     <comment>Message box text for: Main window bookmark delete</comment>
   </data>
   <data name="MessageBox_Undo" xml:space="preserve">
@@ -1531,15 +1530,15 @@ Arguments:
     <comment>Message box text for: Main window Undo</comment>
   </data>
   <data name="MessageBox_WindowTitleIsName" xml:space="preserve">
-    <value>Window Title: {0}</value>
+    <value>Window title: {0}</value>
     <comment>Message box text for: Clipboard set text error, clipboard locked by application name: {0} is the window title of the application locking clipboard</comment>
   </data>
   <data name="MessageBox_WouldYouLikeToContinue" xml:space="preserve">
-    <value>Would you like to continue?</value>
+    <value>Continue?</value>
     <comment>Message box text for: Replace window warning</comment>
   </data>
   <data name="MessageBox_WouldYouLikeToDownloadItNow" xml:space="preserve">
-    <value>Would you like to download it now?</value>
+    <value>Download it now?</value>
     <comment>Message box text for: New dnGrep version</comment>
   </data>
   <data name="MessageBox_YouAreAboutToDeleteFilesFoundDuringSearch" xml:space="preserve">
@@ -1547,19 +1546,19 @@ Arguments:
     <comment>Message box text for: Delete files warning</comment>
   </data>
   <data name="Options_AllowSearchingForFileNamePatternOnly" xml:space="preserve">
-    <value>Allow searching for file name pattern only when 'Search for' is empty</value>
+    <value>List files using the file name pattern when the 'Search for' field is empty</value>
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_ApplicationFonts" xml:space="preserve">
     <value>Application Fonts</value>
-    <comment>Options dialog, fonts group header label</comment>
+    <comment>Options dialog, Application fonts group header label</comment>
   </data>
   <data name="Options_ArchiveAdd" xml:space="preserve">
-    <value>Add:</value>
+    <value>Add</value>
     <comment>Options dialog, archive options text input label</comment>
   </data>
   <data name="Options_ArchiveDefault" xml:space="preserve">
-    <value>Default:</value>
+    <value>Default</value>
     <comment>Options dialog, archive options text input label</comment>
   </data>
   <data name="Options_ArchiveExtensions" xml:space="preserve">
@@ -1567,15 +1566,15 @@ Arguments:
     <comment>Options dialog, archive options label</comment>
   </data>
   <data name="Options_ArchiveOptions" xml:space="preserve">
-    <value>Archive Options</value>
-    <comment>Options dialog, archive options group header label</comment>
+    <value>Archive files</value>
+    <comment>Options dialog, Archive files group header label</comment>
   </data>
   <data name="Options_ArchiveRemove" xml:space="preserve">
-    <value>Remove:</value>
+    <value>Remove</value>
     <comment>Options dialog, archive options text input label</comment>
   </data>
   <data name="Options_BrowseFileLocation" xml:space="preserve">
-    <value>...</value>
+    <value>…</value>
     <comment>Options dialog, browse for file button label</comment>
   </data>
   <data name="Options_CheckDays" xml:space="preserve">
@@ -1583,12 +1582,12 @@ Arguments:
     <comment>Options dialog, check for updates label</comment>
   </data>
   <data name="Options_CheckForUpdatesWhenWindowsStarts" xml:space="preserve">
-    <value>Check for updates when Windows starts</value>
+    <value>Check for new versions when Windows starts</value>
     <comment>Options dialog, check for updates checkbox label (accel)</comment>
   </data>
   <data name="Options_CheckingForUpdates" xml:space="preserve">
-    <value>Checking for updates</value>
-    <comment>Options dialog, check for updates group header label</comment>
+    <value>New versions</value>
+    <comment>Options dialog, New versions group header label</comment>
   </data>
   <data name="Options_ClearOldSearches" xml:space="preserve">
     <value>Clear old searches</value>
@@ -1624,18 +1623,18 @@ Arguments:
   </data>
   <data name="Options_CustomEditorHelp" xml:space="preserve">
     <value>Use keywords '{0}' for file location, '{1}' for the line number, '{2}' for the search pattern, '{3}' for the first matched text on the line, and '{4}' for the column number of the first match on the line.</value>
-    <comment>Options dialog, custom editor help text: the placeholder are non-localizable expressions used as arguments when starting the custom editor</comment>
+    <comment>Options dialog, custom editor help text: the placeholders are non-localized expressions used as arguments when starting the custom editor</comment>
   </data>
   <data name="Options_DetectFileEncodingWhenSearchingForFileNamePatternOnly" xml:space="preserve">
-    <value>Detect file encoding when searching for file name pattern only</value>
+    <value>Detect file encoding when listing files using the file name pattern</value>
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_DialogFontSize" xml:space="preserve">
-    <value>Dialog Font Size</value>
+    <value>Other windows font size</value>
     <comment>Options dialog, font size selector label</comment>
   </data>
   <data name="Options_DnGrepWillAddTheSelectedFiles" xml:space="preserve">
-    <value>dnGrep will add the selected files to the end of the command line.</value>
+    <value>dnGrep will add the selected files to the end of the command-line.</value>
     <comment>Options dialog, compare arguments help text</comment>
   </data>
   <data name="Options_EditorArguments" xml:space="preserve">
@@ -1647,27 +1646,27 @@ Arguments:
     <comment>Options dialog, custom editor command input box label</comment>
   </data>
   <data name="Options_EnableAutomaticCheckingEvery" xml:space="preserve">
-    <value>Enable automatic checking every</value>
+    <value>Check automatically every</value>
     <comment>Options dialog, check for updates, checkbox label (accel)</comment>
   </data>
   <data name="Options_EnablesStartingDnGrepFromTheWindowsExplorerRightClickContextMenu" xml:space="preserve">
     <value>Enables starting dnGrep from the Windows Explorer right-click context menu.</value>
-    <comment>Options dialog, explorer right click menu checkbox tooltip</comment>
+    <comment>Options dialog, explorer right-click menu checkbox tooltip</comment>
   </data>
   <data name="Options_FilesAndIndividualMatches" xml:space="preserve">
     <value>files and individual matches</value>
-    <comment>Options dialog, Replace layout option radio button label (accel)</comment>
+    <comment>Options dialog, Replace window layout option radio button label (accel)</comment>
   </data>
   <data name="Options_FilesOnly" xml:space="preserve">
     <value>files only</value>
     <comment>Options dialog, Replace window layout radio button label (accel)</comment>
   </data>
   <data name="Options_FollowWindowsTheme" xml:space="preserve">
-    <value>Follow Windows Theme</value>
+    <value>Follow Windows theme</value>
     <comment>Options dialog, theme checkbox label (accel)</comment>
   </data>
   <data name="Options_FontFamily" xml:space="preserve">
-    <value>Font Family</value>
+    <value>Font family</value>
     <comment>Options dialog, font selector label</comment>
   </data>
   <data name="Options_HelpTranslateDnGrep" xml:space="preserve">
@@ -1679,8 +1678,8 @@ Arguments:
     <comment>Options dialog, results options combo box label</comment>
   </data>
   <data name="Options_HistoryLists" xml:space="preserve">
-    <value>History Lists</value>
-    <comment>Options dialog, history group heading label</comment>
+    <value>History lists</value>
+    <comment>Options dialog, History group heading label</comment>
   </data>
   <data name="Options_InOptionsExpander" xml:space="preserve">
     <value>in options expander</value>
@@ -1707,15 +1706,15 @@ Arguments:
     <comment>Options dialog, layout group header label</comment>
   </data>
   <data name="Options_LoadFromFile" xml:space="preserve">
-    <value>Load from file...</value>
+    <value>Load from file…</value>
     <comment>Options dialog, language load button label (accel)</comment>
   </data>
   <data name="Options_MainFontSize" xml:space="preserve">
-    <value>Main Font Size</value>
+    <value>Main window font size</value>
     <comment>Options dialog, font size input label</comment>
   </data>
   <data name="Options_MatchEverythingToExactMatch" xml:space="preserve">
-    <value>0 - match everything; 1.0 - exact match</value>
+    <value>0 – match everything; 1.0 – exact match</value>
     <comment>Options dialog, phonetic help text</comment>
   </data>
   <data name="Options_MatchThreshold" xml:space="preserve">
@@ -1727,7 +1726,7 @@ Arguments:
     <comment>Options dialog, regex options text input label</comment>
   </data>
   <data name="Options_OnMainPanel" xml:space="preserve">
-    <value>on main panel</value>
+    <value>on the main panel</value>
     <comment>Options dialog, layout option radio button label (accel)</comment>
   </data>
   <data name="Options_OptionsTitle" xml:space="preserve">
@@ -1739,7 +1738,7 @@ Arguments:
     <comment>Options dialog, PDF to text group header label</comment>
   </data>
   <data name="Options_PdfToTextExeCommandLineOptions" xml:space="preserve">
-    <value>PdfToText.exe command line options:</value>
+    <value>PdfToText.exe command-line options:</value>
     <comment>Options dialog, PDF text input label</comment>
   </data>
   <data name="Options_PdfToTextReset" xml:space="preserve">
@@ -1751,31 +1750,31 @@ Arguments:
     <comment>Options dialog, phonetic group header label</comment>
   </data>
   <data name="Options_PluginAdd" xml:space="preserve">
-    <value>Add:</value>
-    <comment>Options dialog, plugin options text input label</comment>
+    <value>Add</value>
+    <comment>Options dialog, plug-in options text input label</comment>
   </data>
   <data name="Options_PluginDefault" xml:space="preserve">
-    <value>Default:</value>
-    <comment>Options dialog, plugin options text input label</comment>
+    <value>Default</value>
+    <comment>Options dialog, plug-in options text input label</comment>
   </data>
   <data name="Options_PluginEnabled" xml:space="preserve">
     <value>Enabled</value>
-    <comment>Options dialog, plugins checkbox label</comment>
+    <comment>Options dialog, plug-ins checkbox label</comment>
   </data>
   <data name="Options_PluginExtensions" xml:space="preserve">
     <value>Extensions:</value>
-    <comment>Options dialog, plugin options label</comment>
+    <comment>Options dialog, plug-in options label</comment>
   </data>
   <data name="Options_PluginOptions" xml:space="preserve">
-    <value>Plugin Options</value>
-    <comment>Options dialog, plugin options group header label</comment>
+    <value>Plug-ins</value>
+    <comment>Options dialog, Plug-ins group header label</comment>
   </data>
   <data name="Options_PluginRemove" xml:space="preserve">
-    <value>Remove:</value>
-    <comment>Options dialog, plugin options text input label</comment>
+    <value>Remove</value>
+    <comment>Options dialog, plug-in options text input label</comment>
   </data>
   <data name="Options_PressF1ForHelpOnOptions" xml:space="preserve">
-    <value>Press F1 for help on Options</value>
+    <value>Press F1 for help on options</value>
     <comment>Options dialog, help label</comment>
   </data>
   <data name="Options_PreviewToolForTranslators" xml:space="preserve">
@@ -1783,8 +1782,8 @@ Arguments:
     <comment>Options dialog, load language button tooltip</comment>
   </data>
   <data name="Options_RegexOptions" xml:space="preserve">
-    <value>Regex Options</value>
-    <comment>Options dialog, regex options group heading label</comment>
+    <value>Regular expressions</value>
+    <comment>Options dialog, Regular expressions group heading label</comment>
   </data>
   <data name="Options_Reload" xml:space="preserve">
     <value>Reload</value>
@@ -1795,16 +1794,16 @@ Arguments:
     <comment>Options dialog, theme reload button tooltip</comment>
   </data>
   <data name="Options_ReplaceDialogLayout" xml:space="preserve">
-    <value>Replace dialog Layout:</value>
-    <comment>Options dialog, replace view options label</comment>
+    <value>Replace window layout</value>
+    <comment>Options dialog, Replace window layout options label</comment>
   </data>
   <data name="Options_ReplaceFontSize" xml:space="preserve">
-    <value>Replace Font Size</value>
+    <value>Replace window font size</value>
     <comment>Options dialog, font size input label</comment>
   </data>
   <data name="Options_ResultsOptions" xml:space="preserve">
-    <value>Results Options</value>
-    <comment>Options dialog, results options group header label</comment>
+    <value>Search results</value>
+    <comment>Options dialog, Search results group header label</comment>
   </data>
   <data name="Options_SampleText" xml:space="preserve">
     <value>Sample Text</value>
@@ -1815,19 +1814,19 @@ Arguments:
     <comment>Options dialog, save button label (accel)</comment>
   </data>
   <data name="Options_SelectedTheme" xml:space="preserve">
-    <value>Selected Theme</value>
+    <value>Selected theme</value>
     <comment>Options dialog, theme selector label</comment>
   </data>
   <data name="Options_ShowDnGrepInExplorerRightClickMenu" xml:space="preserve">
-    <value>Show dnGrep in Explorer right-click menu</value>
+    <value>Show dnGrep in the right-click menu of Windows Explorer</value>
     <comment>Options dialog, startup options, checkbox label (accel)</comment>
   </data>
   <data name="Options_ShowFileInfoToolTips" xml:space="preserve">
-    <value>Show file info tool tips</value>
+    <value>Show file info tooltips</value>
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_ShowFilePathInResultsPanel" xml:space="preserve">
-    <value>Show file path in results panel</value>
+    <value>Show file path in the results panel</value>
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_ShowResultLinesInContext" xml:space="preserve">
@@ -1839,19 +1838,19 @@ Arguments:
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_ShowSearchOptions" xml:space="preserve">
-    <value>Show search options:</value>
+    <value>Show search options</value>
     <comment>Options dialog, layout options label</comment>
   </data>
   <data name="Options_ShowVerboseMatchCount" xml:space="preserve">
-    <value>Show verbose match count</value>
+    <value>Show additional details about the matches found</value>
     <comment>Options dialog, results options checkbox label (accel)</comment>
   </data>
   <data name="Options_StartupOptions" xml:space="preserve">
-    <value>Startup options</value>
+    <value>Startup</value>
     <comment>Options dialog, startup group header label</comment>
   </data>
   <data name="Options_TheMatchTimeoutLimits" xml:space="preserve">
-    <value>The match timeout limits how long the regular expression engine will attempt to resolve a regular expression before it times out. This prevents processing expressions and input strings that require excessive backtracking.</value>
+    <value>The match timeout limits how long the regular expression engine attempts to resolve a regular expression before it times out. It prevents processing expressions and input strings requiring excessive backtracking.</value>
     <comment>Options dialog, regex options help text</comment>
   </data>
   <data name="Options_Theme" xml:space="preserve">
@@ -1863,7 +1862,7 @@ Arguments:
     <comment>Options dialog, regex options timeout input label</comment>
   </data>
   <data name="Options_ToChangeThisSettingRunDnGREPAsAdministrator" xml:space="preserve">
-    <value>To change this setting run dnGREP as Administrator.</value>
+    <value>Run dnGrep as Administrator to change this setting.</value>
     <comment>Options dialog, Explorer right-click tooltip</comment>
   </data>
   <data name="Options_UseDefault" xml:space="preserve">
@@ -1887,7 +1886,7 @@ Arguments:
     <comment>Preview window, search tool window tooltip</comment>
   </data>
   <data name="Preview_HighlightsDisabledTooManyMatchesFound" xml:space="preserve">
-    <value>Highlights disabled: too many matches found.</value>
+    <value>Not showing highlights because too many matches were found.</value>
     <comment>Preview window, warning text</comment>
   </data>
   <data name="Preview_MatchCase" xml:space="preserve">
@@ -1907,7 +1906,7 @@ Arguments:
     <comment>Preview window, syntax coloring option for no syntax coloring</comment>
   </data>
   <data name="Preview_ThisFileIsEitherBinaryOrTooLargeToPreview" xml:space="preserve">
-    <value>This file is either binary or too large to preview.</value>
+    <value>This file is either binary, or too large to be shown.</value>
     <comment>Preview window, warning message</comment>
   </data>
   <data name="Preview_UseRegularExpressions" xml:space="preserve">
@@ -1915,7 +1914,7 @@ Arguments:
     <comment>Preview window, search tool window tooltip</comment>
   </data>
   <data name="Preview_WrapText" xml:space="preserve">
-    <value>Wrap Text</value>
+    <value>Wrap text</value>
     <comment>Preview window, results options checkbox label (accel)</comment>
   </data>
   <data name="Preview_Zoom" xml:space="preserve">
@@ -1955,7 +1954,7 @@ Arguments:
     <comment>Replace window, File text when attempt to replace in binary file</comment>
   </data>
   <data name="Replace_FileNumberOfCountName" xml:space="preserve">
-    <value>File {0} of {1}: {2}  ({3} matches on {4} lines)</value>
+    <value>File {0} of {1}: {2} ({3} matches on {4} lines)</value>
     <comment>Replace window, file name progress line: {0} is the index of the current file; {1} is the total number of files; {2} is the name of the current file; {3} is the number of matches found in the current file; {4} is the number of lines in the current file with matches</comment>
   </data>
   <data name="Replace_Files" xml:space="preserve">
@@ -1964,7 +1963,7 @@ Arguments:
   </data>
   <data name="Replace_MarkAllMatchesInThisFileForReplacement" xml:space="preserve">
     <value>Mark all matches in this file for replacement [Ctrl+A]</value>
-    <comment>Replace window, Replace in File button tooltip</comment>
+    <comment>Replace window, Replace in file button tooltip</comment>
   </data>
   <data name="Replace_MarkMatchForReplacement" xml:space="preserve">
     <value>Mark match for replacement [Ctrl+R]</value>
@@ -1987,7 +1986,7 @@ Arguments:
     <comment>Replace window, Next button label (accel)</comment>
   </data>
   <data name="Replace_NextFile" xml:space="preserve">
-    <value>Next _File</value>
+    <value>Next _file</value>
     <comment>Replace window, Next file button label (accel)</comment>
   </data>
   <data name="Replace_NumberOfMatchesMarkedForReplacement" xml:space="preserve">
@@ -2003,7 +2002,7 @@ Arguments:
     <comment>Replace window, Previous button label (accel)</comment>
   </data>
   <data name="Replace_PreviousFile" xml:space="preserve">
-    <value>Previous File</value>
+    <value>Previous file</value>
     <comment>Replace window, Previous file button label (accel)</comment>
   </data>
   <data name="Replace_ReadOnly" xml:space="preserve">
@@ -2019,11 +2018,11 @@ Arguments:
     <comment>Replace window, Replace button label (accel)</comment>
   </data>
   <data name="Replace_ReplaceInAllFiles" xml:space="preserve">
-    <value>Replace in All Files</value>
+    <value>Replace in all files</value>
     <comment>Replace window, Replace in all files button label (accel)</comment>
   </data>
   <data name="Replace_ReplaceInFile" xml:space="preserve">
-    <value>Replace in File</value>
+    <value>Replace in file</value>
     <comment>Replace window, Replace in file button label (accel)</comment>
   </data>
   <data name="Replace_ReplaceKey1_Text" xml:space="preserve">
@@ -2031,15 +2030,15 @@ Arguments:
     <comment>Replace window, first color and highlight key label</comment>
   </data>
   <data name="Replace_ReplaceKey2_SelectedMatch" xml:space="preserve">
-    <value>Selected Match</value>
+    <value>Selected match</value>
     <comment>Replace window, second color and highlight key label</comment>
   </data>
   <data name="Replace_ReplaceKey3_ReplaceMatch" xml:space="preserve">
-    <value>Replace Match</value>
+    <value>Replace match</value>
     <comment>Replace window, third color and highlight key label</comment>
   </data>
   <data name="Replace_ReplaceKey4_SkipMatch" xml:space="preserve">
-    <value>Skip Match</value>
+    <value>Skip match</value>
     <comment>Replace window, fourth color and highlight key label</comment>
   </data>
   <data name="Replace_ReplaceMatchesMarkedForReplacement" xml:space="preserve">
@@ -2071,7 +2070,7 @@ Arguments:
     <comment>Replace window, syntax coloring option for no syntax coloring</comment>
   </data>
   <data name="Replace_ThisFileContainsTooManyMatchesForIndividualReplace" xml:space="preserve">
-    <value>This file contains too many matches for individual replace.  To replace all of them, click 'Replace in File'</value>
+    <value>This file contains too many matches for individual replace. Click 'Replace in file' to replace all of them.</value>
     <comment>Replace window, warning message box text</comment>
   </data>
   <data name="Replace_Title" xml:space="preserve">
@@ -2083,7 +2082,7 @@ Arguments:
     <comment>Replace window, Undo button label (accel)</comment>
   </data>
   <data name="Replace_UndoFile" xml:space="preserve">
-    <value>Undo File</value>
+    <value>Undo file</value>
     <comment>Replace window, Undo file button label (accel)</comment>
   </data>
   <data name="Replace_UndoMarkReplaceOnThisMatch" xml:space="preserve">
@@ -2091,7 +2090,7 @@ Arguments:
     <comment>Replace window, Undo button tooltip</comment>
   </data>
   <data name="Replace_WrapText" xml:space="preserve">
-    <value>Wrap Text</value>
+    <value>Wrap text</value>
     <comment>Replace window, results options checkbox label (accel)</comment>
   </data>
   <data name="Replace_Zoom" xml:space="preserve">
@@ -2143,15 +2142,15 @@ Arguments:
     <comment>Report search options summary label</comment>
   </data>
   <data name="ReportSummary_ExcludePattern" xml:space="preserve">
-    <value>Exclude pattern:</value>
+    <value>Exclude file pattern:</value>
     <comment>Report search options summary label</comment>
   </data>
   <data name="ReportSummary_FilePattern" xml:space="preserve">
-    <value>File pattern:</value>
+    <value>Include file pattern:</value>
     <comment>Report search options summary label</comment>
   </data>
   <data name="ReportSummary_MaxFolderDepth" xml:space="preserve">
-    <value>Max folder depth {0}</value>
+    <value>Max folder depth: {0}</value>
     <comment>Report search options summary: {0} is the user input folder depth</comment>
   </data>
   <data name="ReportSummary_Multiline" xml:space="preserve">
@@ -2179,7 +2178,7 @@ Arguments:
     <comment>Report search options summary</comment>
   </data>
   <data name="ReportSummary_NoSymlinks" xml:space="preserve">
-    <value>No symlinks</value>
+    <value>No symbolic links</value>
     <comment>Report search options summary</comment>
   </data>
   <data name="ReportSummary_SearchFor" xml:space="preserve">
@@ -2199,7 +2198,7 @@ Arguments:
     <comment>Report search options summary: {0} and {1} are the user input size range</comment>
   </data>
   <data name="ReportSummary_StopAfterFirstMatch" xml:space="preserve">
-    <value>Stop after frist match</value>
+    <value>Stop after first match</value>
     <comment>Report search options summary</comment>
   </data>
   <data name="ReportSummary_Type0DateFrom1To2" xml:space="preserve">
@@ -2263,7 +2262,7 @@ Arguments:
     <comment>Test window, output results label</comment>
   </data>
   <data name="Test_ReplaceTextIsNotValidXML" xml:space="preserve">
-    <value>Replace text is not valid XML!</value>
+    <value>The replace text is not valid XML!</value>
     <comment>Test window, error text</comment>
   </data>
   <data name="Test_ReplaceWith" xml:space="preserve">
@@ -2335,7 +2334,7 @@ Arguments:
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTA7_ForMoreRegexPatternsHitF1" xml:space="preserve">
-    <value>For more Regex patterns hit F1</value>
+    <value>Hit F1 for more regex patterns</value>
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTB1_ReplacesEntireRegex" xml:space="preserve">
@@ -2343,7 +2342,7 @@ Arguments:
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTB2_InsertsTheTextMatchedIntoTheReplacementText" xml:space="preserve">
-    <value>$1, $2, $3, etc... inserts the text matched between capturing parentheses into the replacement text</value>
+    <value>$1, $2, $3, etc… inserts the text matched between capturing parentheses into the replacement text</value>
     <comment>Main window and Test window tooltip</comment>
   </data>
   <data name="TTB3_InsertsASingleDollarSignIntoTheReplacementText" xml:space="preserve">

--- a/dnGREP.Localization/ResxFile.cs
+++ b/dnGREP.Localization/ResxFile.cs
@@ -70,7 +70,7 @@ namespace dnGREP.Localization
                 else
                 {
                     MessageBox.Show(TranslationSource.Format(Properties.Resources.MessageBox_ResourcesFile0IsNotAResxFile, filePath),
-                        Properties.Resources.MessageBox_DnGrep + "  " + Properties.Resources.MessageBox_LoadResources, 
+                        Properties.Resources.MessageBox_DnGrep + " " + Properties.Resources.MessageBox_LoadResources, 
                         MessageBoxButton.OK, MessageBoxImage.Error, 
                         MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                 }
@@ -79,7 +79,7 @@ namespace dnGREP.Localization
             {
                 logger.Error(ex, $"Failed to load resources file '{filePath}'");
                 MessageBox.Show(TranslationSource.Format(Properties.Resources.MessageBox_CouldNotLoadResourcesFile0, filePath) + ex.Message,
-                    Properties.Resources.MessageBox_DnGrep + "  " + Properties.Resources.MessageBox_LoadResources, 
+                    Properties.Resources.MessageBox_DnGrep + " " + Properties.Resources.MessageBox_LoadResources, 
                     MessageBoxButton.OK, MessageBoxImage.Error,
                     MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
             }

--- a/dnGREP.Localization/dnGREP.Localization.csproj
+++ b/dnGREP.Localization/dnGREP.Localization.csproj
@@ -74,7 +74,9 @@
     <Compile Include="TranslationSource.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.de.resx" />
+    <EmbeddedResource Include="Properties\Resources.de.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.he.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
+++ b/dnGREP.WPF/MVHelpers/ObservableGrepSearchResults.cs
@@ -641,6 +641,8 @@ namespace dnGREP.WPF
 
     public class FormattedGrepLine : CultureAwareViewModel, ITreeItem
     {
+        private readonly string enQuad = char.ConvertFromUtf32(0x2000);
+
         public FormattedGrepLine(GrepLine line, FormattedGrepResult parent, int initialColumnWidth, bool breakSection)
         {
             Parent = parent;
@@ -970,7 +972,7 @@ namespace dnGREP.WPF
                     {
                         if (m.StartLocation + m.Length <= line.LineText.Length)
                         {
-                            paragraph.Inlines.Add(new Run("  "));
+                            paragraph.Inlines.Add(new Run(enQuad));
                             string fmtLine = line.LineText.Substring(m.StartLocation, m.Length);
                             var run = new Run(fmtLine);
                             run.SetResourceReference(Run.ForegroundProperty, "Match.Highlight.Foreground");

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -390,7 +390,7 @@ namespace dnGREP.WPF.UserControls
                         catch (Exception ex)
                         {
                             MessageBox.Show(Localization.Properties.Resources.MessageBox_RenameFailed + ex.Message,
-                                Localization.Properties.Resources.MessageBox_DnGrep + "  " + Localization.Properties.Resources.MessageBox_RenameFile,
+                                Localization.Properties.Resources.MessageBox_DnGrep + " " + Localization.Properties.Resources.MessageBox_RenameFile,
                                 MessageBoxButton.OK, MessageBoxImage.Error,
                                 MessageBoxResult.OK, Localization.TranslationSource.Instance.FlowDirection);
                         }

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -33,6 +33,8 @@ namespace dnGREP.WPF
         private Brush highlightForeground;
         private Brush highlightBackground;
 
+        private readonly string enQuad = char.ConvertFromUtf32(0x2000);
+
         public MainViewModel()
             : base()
         {
@@ -1470,7 +1472,7 @@ namespace dnGREP.WPF
 
                         if (IsEverythingSearchMode && Everything.EverythingSearch.CountMissingFiles > 0)
                         {
-                            StatusMessage += "  " + TranslationSource.Format(Resources.Main_Status_Excluded0MissingFiles, Everything.EverythingSearch.CountMissingFiles);
+                            StatusMessage += enQuad + TranslationSource.Format(Resources.Main_Status_Excluded0MissingFiles, Everything.EverythingSearch.CountMissingFiles);
                         }
                     }
                     else
@@ -1524,7 +1526,7 @@ namespace dnGREP.WPF
                         Environment.NewLine + Environment.NewLine +
                         outdatedEngines + Environment.NewLine + Environment.NewLine +
                         Resources.MessageBox_DefaultEngineWasUsedInstead,
-                        Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_PluginErrors, 
+                        Resources.MessageBox_DnGrep + " " + Resources.MessageBox_PluginErrors, 
                         MessageBoxButton.OK, MessageBoxImage.Warning,
                         MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                 }
@@ -1712,7 +1714,7 @@ namespace dnGREP.WPF
                 if (string.IsNullOrEmpty(ReplaceWith))
                 {
                     if (MessageBox.Show(Resources.MessageBox_AreYouSureYouWantToReplaceSearchPatternWithEmptyString,
-                        Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_Replace, 
+                        Resources.MessageBox_DnGrep + " " + Resources.MessageBox_Replace, 
                         MessageBoxButton.YesNo, MessageBoxImage.Question,
                         MessageBoxResult.Yes, TranslationSource.Instance.FlowDirection) != MessageBoxResult.Yes)
                     {
@@ -1731,7 +1733,7 @@ namespace dnGREP.WPF
                     {
                         sb.AppendLine(" - " + new FileInfo(fileName).Name);
                     }
-                    if (MessageBox.Show(sb.ToString(), Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_Replace,
+                    if (MessageBox.Show(sb.ToString(), Resources.MessageBox_DnGrep + " " + Resources.MessageBox_Replace,
                         MessageBoxButton.YesNo, MessageBoxImage.Question,
                         MessageBoxResult.Yes, TranslationSource.Instance.FlowDirection) != MessageBoxResult.Yes)
                     {
@@ -1794,7 +1796,7 @@ namespace dnGREP.WPF
             {
                 MessageBoxResult response = MessageBox.Show(
                     Resources.MessageBox_UndoWillRevertModifiedFiles,
-                    Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_Undo, 
+                    Resources.MessageBox_DnGrep + " " + Resources.MessageBox_Undo, 
                     MessageBoxButton.YesNo, MessageBoxImage.Warning, 
                     MessageBoxResult.No, TranslationSource.Instance.FlowDirection);
                 if (response == MessageBoxResult.Yes)
@@ -1804,7 +1806,7 @@ namespace dnGREP.WPF
                     if (result)
                     {
                         MessageBox.Show(Resources.MessageBox_FilesHaveBeenSuccessfullyReverted,
-                            Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_Undo, 
+                            Resources.MessageBox_DnGrep + " " + Resources.MessageBox_Undo, 
                             MessageBoxButton.OK, MessageBoxImage.Information,
                             MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                         Utils.DeleteTempFolder();
@@ -1813,7 +1815,7 @@ namespace dnGREP.WPF
                     else
                     {
                         MessageBox.Show(Resources.MessageBox_ThereWasAnErrorRevertingFiles + App.LogDir,
-                            Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_Undo, 
+                            Resources.MessageBox_DnGrep + " " + Resources.MessageBox_Undo, 
                             MessageBoxButton.OK, MessageBoxImage.Error,
                             MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                     }
@@ -2141,7 +2143,7 @@ namespace dnGREP.WPF
                         {
                             MessageBox.Show(Resources.MessageBox_SomeOfTheFilesAreLocatedInTheSelectedDirectory + Environment.NewLine +
                                 Resources.MessageBox_PleaseSelectAnotherDirectoryAndTryAgain,
-                                Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_CopyFiles, 
+                                Resources.MessageBox_DnGrep + " " + Resources.MessageBox_CopyFiles, 
                                 MessageBoxButton.OK, MessageBoxImage.Warning,
                                 MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                             return;
@@ -2158,7 +2160,7 @@ namespace dnGREP.WPF
                             count = Utils.CopyFiles(fileList, destinationFolder, OverwriteFile.Prompt);
                         }
                         MessageBox.Show(TranslationSource.Format(Resources.MessageBox_CountFilesHaveBeenSuccessfullyCopied, count),
-                            Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_CopyFiles,
+                            Resources.MessageBox_DnGrep + " " + Resources.MessageBox_CopyFiles,
                             MessageBoxButton.OK, MessageBoxImage.Information,
                             MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                     }
@@ -2192,7 +2194,7 @@ namespace dnGREP.WPF
                         {
                             MessageBox.Show(Resources.MessageBox_SomeOfTheFilesAreLocatedInTheSelectedDirectory + Environment.NewLine +
                                 Resources.MessageBox_PleaseSelectAnotherDirectoryAndTryAgain,
-                                Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_MoveFiles, 
+                                Resources.MessageBox_DnGrep + " " + Resources.MessageBox_MoveFiles, 
                                 MessageBoxButton.OK, MessageBoxImage.Warning,
                                 MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                             return;
@@ -2209,7 +2211,7 @@ namespace dnGREP.WPF
                             count = Utils.MoveFiles(fileList, destinationFolder, OverwriteFile.Prompt);
                         }
                         MessageBox.Show(TranslationSource.Format(Resources.MessageBox_CountFilesHaveBeenSuccessfullyMoved, count),
-                            Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_MoveFiles, 
+                            Resources.MessageBox_DnGrep + " " + Resources.MessageBox_MoveFiles, 
                             MessageBoxButton.OK, MessageBoxImage.Information,
                             MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                     }
@@ -2236,7 +2238,7 @@ namespace dnGREP.WPF
                 {
                     if (MessageBox.Show(Resources.MessageBox_YouAreAboutToDeleteFilesFoundDuringSearch + Environment.NewLine +
                         Resources.MessageBox_AreYouSureYouWantToContinue,
-                        Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_DeleteFiles, 
+                        Resources.MessageBox_DnGrep + " " + Resources.MessageBox_DeleteFiles, 
                         MessageBoxButton.YesNo, MessageBoxImage.Warning,
                         MessageBoxResult.No, TranslationSource.Instance.FlowDirection) != MessageBoxResult.Yes)
                     {
@@ -2245,7 +2247,7 @@ namespace dnGREP.WPF
 
                     int count = Utils.DeleteFiles(SearchResults.GetList());
                     MessageBox.Show(TranslationSource.Format(Resources.MessageBox_CountFilesHaveBeenSuccessfullyDeleted, count),
-                        Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_DeleteFiles, 
+                        Resources.MessageBox_DnGrep + " " + Resources.MessageBox_DeleteFiles, 
                         MessageBoxButton.OK, MessageBoxImage.Information,
                         MessageBoxResult.OK, TranslationSource.Instance.FlowDirection);
                 }
@@ -2528,7 +2530,7 @@ namespace dnGREP.WPF
                             {
                                 if (MessageBox.Show(TranslationSource.Format(Resources.MessageBox_NewVersionOfDnGREP0IsAvailableForDownload, version) +
                                     Environment.NewLine + Resources.MessageBox_WouldYouLikeToDownloadItNow,
-                                    Resources.MessageBox_DnGrep + "  " + Resources.MessageBox_NewVersion, 
+                                    Resources.MessageBox_DnGrep + " " + Resources.MessageBox_NewVersion, 
                                     MessageBoxButton.YesNo, MessageBoxImage.Information,
                                     MessageBoxResult.Yes, TranslationSource.Instance.FlowDirection) == MessageBoxResult.Yes)
                                 {

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -285,199 +285,10 @@
                             </Expander.Header>
                             <Border BorderBrush="{DynamicResource GroupBox.Border}"
                                     BorderThickness="1" CornerRadius="4">
-                                <WrapPanel SizeChanged="WrapPanel_SizeChanged">
-                                    <!--  left  -->
-                                    <StackPanel x:Name="LeftFileOptions" Margin="3,5,15,0">
-                                        <RadioButton Name="rbFilterAllSizes" Margin="3,0,3,3" GroupName="SizeFilter"
-                                                     TabIndex="20" Content="{l:Loc Key='Main_AllSizes'}"
-                                                     IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=No}" />
-                                        <StackPanel Orientation="Horizontal">
-                                            <RadioButton Name="rbFilterSpecificSize" Margin="3,0,3,3" GroupName="SizeFilter"
-                                                         TabIndex="21" Content="{l:Loc Key='Main_SizeIs'}"
-                                                         IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=Yes}" />
-                                            <TextBox Name="tbFileSizeFrom"
-                                                     Margin="3,0,3,3"
-                                                     IsEnabled="{Binding Path=IsSizeFilterSet}"
-                                                     TabIndex="22" GotFocus="TextBoxFocus"
-                                                     PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
-                                                <TextBox.Width>
-                                                    <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
-                                                        <Binding RelativeSource="{RelativeSource Mode=Self}"/>
-                                                        <Binding Path="ApplicationFontFamily"/>
-                                                        <Binding Path="MainFormFontSize"/>
-                                                    </MultiBinding>
-                                                </TextBox.Width>
-                                                <TextBox.Text>
-                                                    <Binding Path="SizeFrom" UpdateSourceTrigger="PropertyChanged">
-                                                        <Binding.ValidationRules>
-                                                            <ExceptionValidationRule />
-                                                        </Binding.ValidationRules>
-                                                    </Binding>
-                                                </TextBox.Text>
-                                            </TextBox>
-                                            <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_SizeTo'}"
-                                                       Style="{StaticResource LabelTextBlockStyle}" />
-                                            <TextBox Name="tbFileSizeTo"
-                                                     Margin="3,0,3,3"
-                                                     IsEnabled="{Binding Path=IsSizeFilterSet}"
-                                                     TabIndex="23" GotFocus="TextBoxFocus"
-                                                     PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
-                                                <TextBox.Width>
-                                                    <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
-                                                        <Binding RelativeSource="{RelativeSource Mode=Self}"/>
-                                                        <Binding Path="ApplicationFontFamily"/>
-                                                        <Binding Path="MainFormFontSize"/>
-                                                    </MultiBinding>
-                                                </TextBox.Width>
-                                                <TextBox.Text>
-                                                    <Binding Path="SizeTo" UpdateSourceTrigger="PropertyChanged">
-                                                        <Binding.ValidationRules>
-                                                            <ExceptionValidationRule />
-                                                        </Binding.ValidationRules>
-                                                    </Binding>
-                                                </TextBox.Text>
-                                            </TextBox>
-                                            <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_SizeKB'}"
-                                                       Style="{StaticResource LabelTextBlockStyle}" />
-                                        </StackPanel>
-                                        <CheckBox Name="cbIncludeSubfolders" Margin="3,0,3,3"
-                                                  IsChecked="{Binding Path=IncludeSubfolder}"
-                                                  TabIndex="24" Content="{l:Loc Key='Main_IncludeSubfolders'}" />
-                                        <StackPanel Orientation="Horizontal" Margin="26,0">
-                                            <Label Margin="3,0,3,3" Content="{l:Loc Key='Main_MaxDepth'}"
-                                                   Style="{DynamicResource ThemedLabel}"
-                                                   Target="{Binding ElementName=tbMaxDepth}"/>
-                                            <my:DepthTextBox x:Name="tbMaxDepth"  Margin="3,0,3,3"
-                                                     IsEnabled="{Binding Path=IncludeSubfolder}"
-                                                     TabIndex="25" GotFocus="TextBoxFocus"
-                                                     PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
-                                                <TextBox.Width>
-                                                    <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
-                                                        <Binding RelativeSource="{RelativeSource Mode=Self}"/>
-                                                        <Binding Path="ApplicationFontFamily"/>
-                                                        <Binding Path="MainFormFontSize"/>
-                                                    </MultiBinding>
-                                                </TextBox.Width>
-                                                <TextBox.Text>
-                                                    <Binding Path="MaxSubfolderDepth" UpdateSourceTrigger="PropertyChanged"
-                                                             Converter="{StaticResource IntConverter}">
-                                                        <Binding.ValidationRules>
-                                                            <ExceptionValidationRule />
-                                                        </Binding.ValidationRules>
-                                                    </Binding>
-                                                </TextBox.Text>
-                                            </my:DepthTextBox>
-                                        </StackPanel>
-
-                                        <CheckBox Name="cbIncludeHiddenFolders" Margin="3,0,3,3"
-                                                  IsChecked="{Binding Path=IncludeHidden}"
-                                                  TabIndex="26" Content="{l:Loc Key='Main_IncludeHiddenFolders'}" />
-                                        <CheckBox Name="cbIncludeBinary" Margin="3,0,3,3"
-                                                  IsChecked="{Binding Path=IncludeBinary}"
-                                                  TabIndex="27" Content="{l:Loc Key='Main_IncludeBinaryFiles'}" />
-                                        <CheckBox Name="cbFollowSymlinks" Margin="3,0,3,3"
-                                                  IsChecked="{Binding Path=FollowSymlinks}"
-                                                  TabIndex="28" Content="{l:Loc Key='Main_FollowSymbolicLinks'}" />
-                                    </StackPanel>
-                                    <!--  middle  -->
-                                    <StackPanel x:Name="MiddleFileOptions" Margin="3,5,15,3" VerticalAlignment="Top"
-                                                Orientation="Vertical">
-                                        <StackPanel Margin="-6,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                    Orientation="Horizontal">
-                                            <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_AllDates'}"
-                                                         TabIndex="30"
-                                                         IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=None}" />
-                                            <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_Modified'}"
-                                                         TabIndex="31"
-                                                         IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Modified}" />
-                                            <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_Created'}"
-                                                         TabIndex="32"
-                                                         IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Created}" />
-                                        </StackPanel>
-                                        <Grid>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition />
-                                                <RowDefinition />
-                                            </Grid.RowDefinitions>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <RadioButton Grid.Row="0" Grid.Column="0" Margin="3,0,3,6"
-                                                         GroupName="TimeRange" Content="{l:Loc Key='Main_DateFrom'}"
-                                                         IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Dates}"
-                                                         IsEnabled="{Binding Path=IsDateFilterSet}"
-                                                         TabIndex="33" />
-                                            <DatePicker x:Name="dpFrom" Grid.Row="0" Grid.Column="1"
-                                                        Margin="3,0,3,2" TabIndex="34"
-                                                        ToolTip="{l:Loc Key='Main_FromTheStartOfTheDay'}"
-                                                        CalendarStyle="{StaticResource CalendarStyle}"
-                                                        DisplayDate="{x:Static sys:DateTime.Now}"
-                                                        DisplayDateStart="{Binding MinStartDate}"
-                                                        SelectedDate="{Binding StartDate}"
-                                                        IsEnabled="{Binding IsDatesRangeSet}" />
-                                            <TextBlock Grid.Row="1" Grid.Column="0" Margin="20,0,0,6"
-                                                       Text="{l:Loc Key='Main_DateTo'}"
-                                                       Style="{StaticResource LabelTextBlockStyle}" />
-                                            <DatePicker x:Name="dpTo" Grid.Row="1" Grid.Column="1"
-                                                        Margin="3,0,3,2" TabIndex="35"
-                                                        ToolTip="{l:Loc Key='Main_ThroughTheEndOfTheDay'}"
-                                                        CalendarStyle="{StaticResource CalendarStyle}"
-                                                        DisplayDateStart="{Binding MinEndDate}"
-                                                        DisplayDate="{x:Static sys:DateTime.Now}"
-                                                        SelectedDate="{Binding EndDate}"
-                                                        IsEnabled="{Binding IsDatesRangeSet}" />
-                                        </Grid>
-                                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Orientation="Horizontal">
-                                            <RadioButton Margin="3,0,3,3" GroupName="TimeRange" 
-                                                         Content="{l:Loc Key='Main_DatePast'}"
-                                                         IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Hours}"
-                                                         IsEnabled="{Binding Path=IsDateFilterSet}"
-                                                         TabIndex="36" />
-                                            <TextBox Margin="9,0,3,3"
-                                                     HorizontalAlignment="Center"
-                                                     IsEnabled="{Binding IsHoursRangeSet}"
-                                                     TabIndex="37" GotFocus="TextBoxFocus"
-                                                     PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting"
-                                                     Text="{Binding HoursFrom, UpdateSourceTrigger=PropertyChanged}">
-                                                <TextBox.Width>
-                                                    <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="45" FallbackValue="45">
-                                                        <Binding RelativeSource="{RelativeSource Mode=Self}"/>
-                                                        <Binding Path="ApplicationFontFamily"/>
-                                                        <Binding Path="MainFormFontSize"/>
-                                                    </MultiBinding>
-                                                </TextBox.Width>
-                                            </TextBox>
-
-                                            <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_PastDateTo'}"
-                                                       Style="{StaticResource LabelTextBlockStyle}" />
-                                            <TextBox Margin="3,0,3,3"
-                                                     HorizontalAlignment="Center"
-                                                     IsEnabled="{Binding IsHoursRangeSet}"
-                                                     TabIndex="38" GotFocus="TextBoxFocus"
-                                                     PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
-                                                <TextBox.Width>
-                                                    <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="45" FallbackValue="45">
-                                                        <Binding RelativeSource="{RelativeSource Mode=Self}"/>
-                                                        <Binding Path="ApplicationFontFamily"/>
-                                                        <Binding Path="MainFormFontSize"/>
-                                                    </MultiBinding>
-                                                </TextBox.Width>
-                                                <TextBox.Text>
-                                                    <Binding Path="HoursTo" UpdateSourceTrigger="PropertyChanged">
-                                                        <Binding.ValidationRules>
-                                                            <ExceptionValidationRule />
-                                                        </Binding.ValidationRules>
-                                                    </Binding>
-                                                </TextBox.Text>
-                                            </TextBox>
-                                            <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_DatePastHours'}"
-                                                       Style="{StaticResource LabelTextBlockStyle}" />
-                                        </StackPanel>
-                                    </StackPanel>
-                                    <Border x:Name="SpacerFileOptions" />
-                                    <!--  right  -->
-                                    <Grid x:Name="RightFileOptions" Margin="3,5,3,3">
+                                <DockPanel>
+                                    <!--  right panel first so it has size precedence  -->
+                                    <Grid x:Name="RightFileOptions" DockPanel.Dock="Right"
+                                          Margin="3,5,3,3">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
@@ -541,9 +352,15 @@
                                                 </ComboBox.Width>
                                             </ComboBox>
                                         </StackPanel>
-                                        <Grid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
-                                                     Margin="4,3,3,3"
-                                                     Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
+                                        <Button Grid.Row="3" Grid.Column="1"
+                                                Margin="3,0,3,3"  Padding="8,3" HorizontalAlignment="Right"
+                                                HorizontalContentAlignment="Center" 
+                                                Content="{l:Loc Key='Main_ResetOptions'}"
+                                                Command="{Binding ResetOptionsCommand}"
+                                                TabIndex="49" />
+                                        <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                                              Margin="4,3,3,3"
+                                              Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource InverseBoolToVisibilityConverter}}">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition/>
                                                 <RowDefinition/>
@@ -574,15 +391,207 @@
                                                       IsEnabled="{Binding IsBooleanOperatorsEnabled}"
                                                       TabIndex="48" Content="{l:Loc Key='Main_BooleanOperators'}" 
                                                       ToolTip="{l:Loc Key='Main_CombineMultipleSearchPatternsUsingANDOrOR'}"/>
+                                            <CheckBox Grid.Row="2" Grid.Column="1" Margin="3,0,3,3"
+                                                      IsChecked="{Binding CaptureGroupSearch}"
+                                                      IsEnabled="{Binding Path=TypeOfFileSearch, Converter={StaticResource ebc}, ConverterParameter=Regex}"
+                                                      TabIndex="48" Content="{l:Loc Key='Main_CaptureGroupSearch'}" 
+                                                      ToolTip="{l:Loc Key='Main_UseCaptureGroupsFromPathsToMatch'}"/>
                                         </Grid>
-                                        <Button Grid.Row="4" Grid.Column="1"
-                                                Margin="3,0,3,3" HorizontalAlignment="Right"
-                                                HorizontalContentAlignment="Center" 
-                                                Content="{l:Loc Key='Main_ResetOptions'}"
-                                                Command="{Binding ResetOptionsCommand}"
-                                                TabIndex="49" />
                                     </Grid>
-                                </WrapPanel>
+                                    <!-- Left and middle panels in the expander wrap for narrow windows -->
+                                    <WrapPanel DockPanel.Dock="Left">
+                                        <!--  left panel  -->
+                                        <StackPanel x:Name="LeftFileOptions" Margin="3,5,15,0">
+                                            <RadioButton Name="rbFilterAllSizes" Margin="3,0,3,3" GroupName="SizeFilter"
+                                                         TabIndex="20" Content="{l:Loc Key='Main_AllSizes'}"
+                                                         IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=No}" />
+                                            <StackPanel Orientation="Horizontal">
+                                                <RadioButton Name="rbFilterSpecificSize" Margin="3,0,3,3" GroupName="SizeFilter"
+                                                             TabIndex="21" Content="{l:Loc Key='Main_SizeIs'}"
+                                                             IsChecked="{Binding Path=UseFileSizeFilter, Converter={StaticResource ebc}, ConverterParameter=Yes}" />
+                                                <TextBox Name="tbFileSizeFrom"
+                                                         Margin="3,0,3,3"
+                                                         IsEnabled="{Binding Path=IsSizeFilterSet}"
+                                                         TabIndex="22" GotFocus="TextBoxFocus"
+                                                         PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                                    <TextBox.Width>
+                                                        <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
+                                                            <Binding RelativeSource="{RelativeSource Mode=Self}"/>
+                                                            <Binding Path="ApplicationFontFamily"/>
+                                                            <Binding Path="MainFormFontSize"/>
+                                                        </MultiBinding>
+                                                    </TextBox.Width>
+                                                    <TextBox.Text>
+                                                        <Binding Path="SizeFrom" UpdateSourceTrigger="PropertyChanged">
+                                                            <Binding.ValidationRules>
+                                                                <ExceptionValidationRule />
+                                                            </Binding.ValidationRules>
+                                                        </Binding>
+                                                    </TextBox.Text>
+                                                </TextBox>
+                                                <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_SizeTo'}"
+                                                           Style="{StaticResource LabelTextBlockStyle}" />
+                                                <TextBox Name="tbFileSizeTo"
+                                                         Margin="3,0,3,3"
+                                                         IsEnabled="{Binding Path=IsSizeFilterSet}"
+                                                         TabIndex="23" GotFocus="TextBoxFocus"
+                                                         PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                                    <TextBox.Width>
+                                                        <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
+                                                            <Binding RelativeSource="{RelativeSource Mode=Self}"/>
+                                                            <Binding Path="ApplicationFontFamily"/>
+                                                            <Binding Path="MainFormFontSize"/>
+                                                        </MultiBinding>
+                                                    </TextBox.Width>
+                                                    <TextBox.Text>
+                                                        <Binding Path="SizeTo" UpdateSourceTrigger="PropertyChanged">
+                                                            <Binding.ValidationRules>
+                                                                <ExceptionValidationRule />
+                                                            </Binding.ValidationRules>
+                                                        </Binding>
+                                                    </TextBox.Text>
+                                                </TextBox>
+                                                <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_SizeKB'}"
+                                                           Style="{StaticResource LabelTextBlockStyle}" />
+                                            </StackPanel>
+                                            <CheckBox Name="cbIncludeSubfolders" Margin="3,0,3,3"
+                                                      IsChecked="{Binding Path=IncludeSubfolder}"
+                                                      TabIndex="24" Content="{l:Loc Key='Main_IncludeSubfolders'}" />
+                                            <StackPanel Orientation="Horizontal" Margin="26,0">
+                                                <Label Margin="3,0,3,3" Content="{l:Loc Key='Main_MaxDepth'}"
+                                                       Style="{DynamicResource ThemedLabel}"
+                                                       Target="{Binding ElementName=tbMaxDepth}"/>
+                                                <my:DepthTextBox x:Name="tbMaxDepth"  Margin="3,0,3,3"
+                                                         IsEnabled="{Binding Path=IncludeSubfolder}"
+                                                         TabIndex="25" GotFocus="TextBoxFocus"
+                                                         PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                                    <TextBox.Width>
+                                                        <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="48" FallbackValue="48">
+                                                            <Binding RelativeSource="{RelativeSource Mode=Self}"/>
+                                                            <Binding Path="ApplicationFontFamily"/>
+                                                            <Binding Path="MainFormFontSize"/>
+                                                        </MultiBinding>
+                                                    </TextBox.Width>
+                                                    <TextBox.Text>
+                                                        <Binding Path="MaxSubfolderDepth" UpdateSourceTrigger="PropertyChanged"
+                                                                 Converter="{StaticResource IntConverter}">
+                                                            <Binding.ValidationRules>
+                                                                <ExceptionValidationRule />
+                                                            </Binding.ValidationRules>
+                                                        </Binding>
+                                                    </TextBox.Text>
+                                                </my:DepthTextBox>
+                                            </StackPanel>
+
+                                            <CheckBox Name="cbIncludeHiddenFolders" Margin="3,0,3,3"
+                                                      IsChecked="{Binding Path=IncludeHidden}"
+                                                      TabIndex="26" Content="{l:Loc Key='Main_IncludeHiddenFolders'}" />
+                                            <CheckBox Name="cbIncludeBinary" Margin="3,0,3,3"
+                                                      IsChecked="{Binding Path=IncludeBinary}"
+                                                      TabIndex="27" Content="{l:Loc Key='Main_IncludeBinaryFiles'}" />
+                                            <CheckBox Name="cbFollowSymlinks" Margin="3,0,3,3"
+                                                      IsChecked="{Binding Path=FollowSymlinks}"
+                                                      TabIndex="28" Content="{l:Loc Key='Main_FollowSymbolicLinks'}" />
+                                        </StackPanel>
+                                        <!--  middle panel -->
+                                        <StackPanel x:Name="MiddleFileOptions" Margin="3,5,15,3" VerticalAlignment="Top"
+                                                    Orientation="Vertical">
+                                            <StackPanel Margin="0,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                        Orientation="Horizontal">
+                                                <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_AllDates'}"
+                                                             TabIndex="30"
+                                                             IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=None}" />
+                                                <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_Modified'}"
+                                                             TabIndex="31"
+                                                             IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Modified}" />
+                                                <RadioButton Margin="3,0,3,3" GroupName="DateFilter" Content="{l:Loc Key='Main_Created'}"
+                                                             TabIndex="32"
+                                                             IsChecked="{Binding Path=UseFileDateFilter, Converter={StaticResource ebc}, ConverterParameter=Created}" />
+                                            </StackPanel>
+                                            <Grid Margin="8,0,0,0">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition />
+                                                    <RowDefinition />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <RadioButton Grid.Row="0" Grid.Column="0" Margin="3,0,6,6"
+                                                             GroupName="TimeRange" Content="{l:Loc Key='Main_DateFrom'}"
+                                                             IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Dates}"
+                                                             IsEnabled="{Binding Path=IsDateFilterSet}"
+                                                             TabIndex="33" />
+                                                <DatePicker x:Name="dpFrom" Grid.Row="0" Grid.Column="1"
+                                                            Margin="3,0,3,2" TabIndex="34"
+                                                            ToolTip="{l:Loc Key='Main_FromTheStartOfTheDay'}"
+                                                            CalendarStyle="{StaticResource CalendarStyle}"
+                                                            DisplayDate="{x:Static sys:DateTime.Now}"
+                                                            DisplayDateStart="{Binding MinStartDate}"
+                                                            SelectedDate="{Binding StartDate}"
+                                                            IsEnabled="{Binding IsDatesRangeSet}" />
+                                                    <TextBlock Grid.Row="1" Grid.Column="0" Margin="3,0,6,6"
+                                                           HorizontalAlignment="Right"
+                                                           Text="{l:Loc Key='Main_DateTo'}"
+                                                           Style="{StaticResource LabelTextBlockStyle}" />
+                                                <DatePicker x:Name="dpTo" Grid.Row="1" Grid.Column="1"
+                                                            Margin="3,0,3,2" TabIndex="35"
+                                                            ToolTip="{l:Loc Key='Main_ThroughTheEndOfTheDay'}"
+                                                            CalendarStyle="{StaticResource CalendarStyle}"
+                                                            DisplayDateStart="{Binding MinEndDate}"
+                                                            DisplayDate="{x:Static sys:DateTime.Now}"
+                                                            SelectedDate="{Binding EndDate}"
+                                                            IsEnabled="{Binding IsDatesRangeSet}" />
+                                            </Grid>
+                                            <StackPanel Margin="8,0,0,0" Orientation="Horizontal">
+                                                <RadioButton Margin="3,0,3,3" GroupName="TimeRange" 
+                                                             Content="{l:Loc Key='Main_DatePast'}"
+                                                             IsChecked="{Binding Path=TypeOfTimeRangeFilter, Converter={StaticResource ebc}, ConverterParameter=Hours}"
+                                                             IsEnabled="{Binding Path=IsDateFilterSet}"
+                                                             TabIndex="36" />
+                                                <TextBox Margin="12,0,3,3"
+                                                         HorizontalAlignment="Center"
+                                                         IsEnabled="{Binding IsHoursRangeSet}"
+                                                         TabIndex="37" GotFocus="TextBoxFocus"
+                                                         PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting"
+                                                         Text="{Binding HoursFrom, UpdateSourceTrigger=PropertyChanged}">
+                                                    <TextBox.Width>
+                                                        <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="45" FallbackValue="45">
+                                                            <Binding RelativeSource="{RelativeSource Mode=Self}"/>
+                                                            <Binding Path="ApplicationFontFamily"/>
+                                                            <Binding Path="MainFormFontSize"/>
+                                                        </MultiBinding>
+                                                    </TextBox.Width>
+                                                </TextBox>
+
+                                                <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_PastDateTo'}"
+                                                           Style="{StaticResource LabelTextBlockStyle}" />
+                                                <TextBox Margin="3,0,3,3"
+                                                         HorizontalAlignment="Center"
+                                                         IsEnabled="{Binding IsHoursRangeSet}"
+                                                         TabIndex="38" GotFocus="TextBoxFocus"
+                                                         PreviewTextInput="TextBox_PreviewTextInput" DataObject.Pasting="TextBoxPasting">
+                                                    <TextBox.Width>
+                                                        <MultiBinding Converter="{StaticResource TextBoxWidthConverter}" ConverterParameter="45" FallbackValue="45">
+                                                            <Binding RelativeSource="{RelativeSource Mode=Self}"/>
+                                                            <Binding Path="ApplicationFontFamily"/>
+                                                            <Binding Path="MainFormFontSize"/>
+                                                        </MultiBinding>
+                                                    </TextBox.Width>
+                                                    <TextBox.Text>
+                                                        <Binding Path="HoursTo" UpdateSourceTrigger="PropertyChanged">
+                                                            <Binding.ValidationRules>
+                                                                <ExceptionValidationRule />
+                                                            </Binding.ValidationRules>
+                                                        </Binding>
+                                                    </TextBox.Text>
+                                                </TextBox>
+                                                <TextBlock Margin="3,0,3,3" Text="{l:Loc Key='Main_DatePastHours'}"
+                                                           Style="{StaticResource LabelTextBlockStyle}" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </WrapPanel>
+                                </DockPanel>
                             </Border>
                         </Expander>
                         <!--  must be *after* the Expander so they are higher in the z-order  -->
@@ -646,7 +655,7 @@
                                       IsChecked="{Binding IsBookmarked}"
                                       Command="{Binding BookmarkAddCommand}"
                                       DockPanel.Dock="Right" TabIndex="54" />
-                            <StackPanel Margin="75,0,0,0" Orientation="Horizontal" DockPanel.Dock="Left">
+                            <StackPanel Margin="0,0,0,0" Orientation="Horizontal" DockPanel.Dock="Left">
                                 <RadioButton Margin="3" Content="{l:Loc Key='Main_SearchType_Regex'}" GroupName="SearchRegex"
                                              IsChecked="{Binding TypeOfSearch, ConverterParameter=Regex, Converter={StaticResource ebc}}"
                                              ToolTip="{l:Loc Key='Main_SearchType_RegularExpressionSearch'}" TabIndex="50" />
@@ -667,7 +676,7 @@
                         </DockPanel>
                         <StackPanel Margin="0,5,0,3" DockPanel.Dock="Bottom"
                                     Visibility="{Binding OptionsOnMainPanel, Converter={StaticResource BoolToVisibilityConverter}}">
-                            <WrapPanel Margin="77,0,0,0" Orientation="Horizontal">
+                            <WrapPanel Margin="0,0,0,0" Orientation="Horizontal">
                                 <CheckBox Margin="3"
                                           IsChecked="{Binding CaseSensitive}"
                                           IsEnabled="{Binding IsCaseSensitiveEnabled}"

--- a/dnGREP.WPF/Views/MainView.xaml.cs
+++ b/dnGREP.WPF/Views/MainView.xaml.cs
@@ -367,17 +367,6 @@ namespace dnGREP.WPF
                 ((ComboBox)sender).SelectedIndex = 0;
         }
 
-        private void WrapPanel_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            var panel = (WrapPanel)sender;
-
-            var maxWidth = panel.ActualWidth -
-                LeftFileOptions.ActualWidth - LeftFileOptions.Margin.Left - LeftFileOptions.Margin.Right -
-                MiddleFileOptions.ActualWidth - MiddleFileOptions.Margin.Left - MiddleFileOptions.Margin.Right -
-                RightFileOptions.ActualWidth - RightFileOptions.Margin.Left - RightFileOptions.Margin.Right;
-            SpacerFileOptions.Width = Math.Max(0, maxWidth);
-        }
-
         private void Expander_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             // set the max width of the File Filters Summary text block so the Search In Archives checkbox does not overlap it

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -340,18 +340,18 @@
 
                 <GroupBox Header="{l:Loc Key='Options_Layout'}">
                     <StackPanel>
-                        <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
+                        <StackPanel Margin="0,6,0,0">
                             <TextBlock Text="{l:Loc Key='Options_ShowSearchOptions'}" />
-                            <RadioButton Margin="18,0" Content="{l:Loc Key='Options_OnMainPanel'}" GroupName="searchLocation"
+                            <RadioButton Margin="18,3" Content="{l:Loc Key='Options_OnMainPanel'}" GroupName="searchLocation"
                                          IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=MainPanel}" />
-                            <RadioButton Margin="3,0" Content="{l:Loc Key='Options_InOptionsExpander'}" GroupName="searchLocation"
+                            <RadioButton Margin="18,3" Content="{l:Loc Key='Options_InOptionsExpander'}" GroupName="searchLocation"
                                          IsChecked="{Binding OptionsLocation, Converter={StaticResource ebc}, ConverterParameter=OptionsExpander}" />
                         </StackPanel>
-                        <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
+                        <StackPanel Margin="0,6,0,0">
                             <TextBlock Text="{l:Loc Key='Options_ReplaceDialogLayout'}" />
-                            <RadioButton Margin="18,0" Content="{l:Loc Key='Options_FilesAndIndividualMatches'}" GroupName="replaceLayout"
+                            <RadioButton Margin="18,3" Content="{l:Loc Key='Options_FilesAndIndividualMatches'}" GroupName="replaceLayout"
                                          IsChecked="{Binding ReplaceDialogLayout, Converter={StaticResource ebc}, ConverterParameter=FullDialog}" />
-                            <RadioButton Margin="3,0" Content="{l:Loc Key='Options_FilesOnly'}" GroupName="replaceLayout"
+                            <RadioButton Margin="18,3" Content="{l:Loc Key='Options_FilesOnly'}" GroupName="replaceLayout"
                                          IsChecked="{Binding ReplaceDialogLayout, Converter={StaticResource ebc}, ConverterParameter=FilesOnly}" />
                         </StackPanel>
                     </StackPanel>
@@ -390,23 +390,24 @@
                             <Label Content="{l:Loc Key='Options_ContextAfter'}" />
                         </StackPanel>
 
-                        <CheckBox Name="cbSearchFileNameOnly" Margin="3"
-                                  IsChecked="{Binding Path=AllowSearchWithEmptyPattern}">
-                            <CheckBox.Content>
-                                <TextBlock Text="{l:Loc Key='Options_AllowSearchingForFileNamePatternOnly'}"/>
-                            </CheckBox.Content>
-                        </CheckBox>
+                        <CheckBox Name="cbSearchFileNameOnly" Margin="3" 
+                                  Content="{l:Loc Key='Options_AllowSearchingForFileNamePatternOnly'}"
+                                  IsChecked="{Binding Path=AllowSearchWithEmptyPattern}"/>
 
-                        <CheckBox Name="cbCheckEncoding" Margin="3" Content="{l:Loc Key='Options_DetectFileEncodingWhenSearchingForFileNamePatternOnly'}"
-                                  IsChecked="{Binding Path=DetectEncodingForFileNamePattern}" />
+                        <CheckBox Name="cbCheckEncoding" Margin="3"
+                                  Content="{l:Loc Key='Options_DetectFileEncodingWhenSearchingForFileNamePatternOnly'}"
+                                  IsChecked="{Binding Path=DetectEncodingForFileNamePattern}"/>
 
-                        <CheckBox Name="cbExpandResult" Margin="3" Content="{l:Loc Key='Options_ShowResultsTreeExpanded'}"
+                        <CheckBox Name="cbExpandResult" Margin="3" 
+                                  Content="{l:Loc Key='Options_ShowResultsTreeExpanded'}"
                                   IsChecked="{Binding Path=AutoExpandSearchTree}" />
 
-                        <CheckBox Name="cbShowMatchVerbose" Margin="3" Content="{l:Loc Key='Options_ShowVerboseMatchCount'}"
+                        <CheckBox Name="cbShowMatchVerbose" Margin="3" 
+                                  Content="{l:Loc Key='Options_ShowVerboseMatchCount'}"
                                   IsChecked="{Binding Path=ShowVerboseMatchCount}" />
 
-                        <CheckBox Name="cbShowFileInfoToolTips" Margin="3" Content="{l:Loc Key='Options_ShowFileInfoToolTips'}"
+                        <CheckBox Name="cbShowFileInfoToolTips" Margin="3" 
+                                  Content="{l:Loc Key='Options_ShowFileInfoToolTips'}"
                                   IsChecked="{Binding Path=ShowFileInfoTooltips}" />
 
                         <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
Summary:
Changes to English language resource including many of comradekingu's requests and using the Microsoft [Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
* Change labels to `Sentence case` consistently, from `Title Case`.
* Change dnGREP to dnGrep
* Change Regex to Regular Expression
* Change Hex to Byte
* Change Asterisk to Wildcard
* Expand some abbreviated terms and phrases
* Change three periods to the the Unicode ellipses character
* Revise the text in message boxes for clarity
* Removed double spaces
* Fix spelling
* Changes to the main windows layout to accommodate longer strings
* Changes to the options window layout to accommodate longer strings