### PR TITLE
1373 - fix slow performance on large result sets

### DIFF
--- a/dnGREP.Common/GrepSearchResult.cs
+++ b/dnGREP.Common/GrepSearchResult.cs
@@ -148,6 +148,31 @@ namespace dnGREP.Common
 
         public bool IsReadOnlyFileType { get; set; } = false;
 
+        public bool IsReadOnly
+        {
+            get
+            {
+                if (IsHexFile)
+                {
+                    return true;
+                }
+
+                if (IsReadOnlyFileType)
+                {
+                    return true;
+                }
+
+                try
+                {
+                    return File.GetAttributes(FileNameReal).HasFlag(FileAttributes.ReadOnly);
+                }
+                catch
+                {
+                    return true;
+                }
+            }
+        }
+
         private List<GrepLine>? searchResults;
 
         public bool HasSearchResults

--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -1948,33 +1948,13 @@ namespace dnGREP.Common
             {
                 if (!files.Contains(result.FileNameReal))
                 {
-                    if (IsReadOnly(result))
+                    if (result.IsReadOnly)
                     {
                         files.Add(result.FileNameReal);
                     }
                 }
             }
             return files;
-        }
-
-        public static bool IsReadOnly(GrepSearchResult result)
-        {
-            if (result.IsHexFile)
-            {
-                return true;
-            }
-
-            if (result.IsReadOnlyFileType)
-            {
-                return true;
-            }
-
-            if (File.Exists(result.FileNameReal))
-            {
-                return File.GetAttributes(result.FileNameReal).HasFlag(FileAttributes.ReadOnly);
-            }
-
-            return false;
         }
 
         public static bool HasReadOnlyAttributeSet(GrepSearchResult? result)

--- a/dnGREP.WPF.sln
+++ b/dnGREP.WPF.sln
@@ -286,11 +286,10 @@ Global
 		{8312CAE2-B208-4186-B711-815593FEBB94} = {177DCA75-DAA1-4097-A3AB-EF944566600D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_Rules = {"EnabledRules":["StringFormat","WhiteSpaceLead","WhiteSpaceTail","PunctuationLead","PunctuationTail"]}
-		RESX_SortFileContentOnSave = False
-		RESX_MoveToResources = {"Items":[{"Extensions":".cs,.vb","Patterns":"$Namespace.$File.$Key|$File.$Key|StringResourceKey.$Key|$Namespace.StringResourceKey.$Key|nameof($File.$Key), ResourceType = typeof($File)|ErrorMessageResourceType = typeof($File), ErrorMessageResourceName = nameof($File.$Key)"},{"Extensions":".cshtml,.vbhtml","Patterns":"@$Namespace.$File.$Key|@$File.$Key|@StringResourceKey.$Key|@$Namespace.StringResourceKey.$Key"},{"Extensions":".cpp,.c,.hxx,.h","Patterns":"$File::$Key"},{"Extensions":".aspx,.ascx","Patterns":"<%$ Resources:$File,$Key %>|<%= $File.$Key %>|<%= $Namespace.$File.$Key %>"},{"Extensions":".xaml","Patterns":"\"{l:Loc Key='$Key'}\""},{"Extensions":".ts","Patterns":"resources.$Key"},{"Extensions":".html","Patterns":"{{ resources.$Key }}"}]}
-		RESX_ResXSortingComparison = InvariantCulture
 		SolutionGuid = {835B141D-24DE-4FDA-805E-B7871861B348}
+		RESX_ResXSortingComparison = InvariantCulture
+		RESX_SortFileContentOnSave = False
+		RESX_Rules = {"EnabledRules":["StringFormat","WhiteSpaceLead","WhiteSpaceTail","PunctuationLead","PunctuationTail"]}
 	EndGlobalSection
 	GlobalSection(SharpSetup) = preSolution
 		Version = 1.2

--- a/dnGREP.WPF/MVHelpers/ResultSorter.cs
+++ b/dnGREP.WPF/MVHelpers/ResultSorter.cs
@@ -212,8 +212,8 @@ namespace dnGREP.WPF.MVHelpers
             var left = direction == ListSortDirection.Ascending ? x : y;
             var right = direction == ListSortDirection.Ascending ? y : x;
 
-            bool isLeftFileReadOnly = left == null || Utils.IsReadOnly(left.GrepResult);
-            bool isRightFileReadOnly = right == null || Utils.IsReadOnly(right.GrepResult);
+            bool isLeftFileReadOnly = left == null || left.GrepResult.IsReadOnly;
+            bool isRightFileReadOnly = right == null || right.GrepResult.IsReadOnly;
 
             if (isLeftFileReadOnly != isRightFileReadOnly)
                 return isRightFileReadOnly.CompareTo(isLeftFileReadOnly);

--- a/dnGREP.WPF/ViewModels/FormattedGrepResult.cs
+++ b/dnGREP.WPF/ViewModels/FormattedGrepResult.cs
@@ -134,7 +134,7 @@ namespace dnGREP.WPF
 
         internal void SetLabel()
         {
-            bool isFileReadOnly = Utils.IsReadOnly(GrepResult);
+            bool isFileReadOnly = GrepResult.IsReadOnly;
 
             string basePath = string.IsNullOrWhiteSpace(searchFolderPath) ? string.Empty : searchFolderPath;
             FileName = Path.GetFileName(GrepResult.FileNameDisplayed);

--- a/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
@@ -328,20 +328,19 @@ namespace dnGREP.WPF
         }
 
         /// <summary>
-        /// Gets the list of results that are writable
+        /// Gets the set of results that are writable and have matches
         /// </summary>
         /// <returns></returns>
-        public List<GrepSearchResult> GetWritableList()
+        public IEnumerable<GrepSearchResult> GetWritableFilesWithMatches()
         {
-            List<GrepSearchResult> writableFiles = [];
             foreach (var item in SearchResults)
             {
-                if (!Utils.IsReadOnly(item.GrepResult))
+                if (item.GrepResult.Matches.Any() &&
+                    !item.GrepResult.IsReadOnly)
                 {
-                    writableFiles.Add(item.GrepResult);
+                    yield return item.GrepResult;
                 }
             }
-            return writableFiles;
         }
 
         public void AddRange(List<GrepSearchResult> list)
@@ -524,7 +523,7 @@ namespace dnGREP.WPF
                 {
                     if (!files.Contains(fileNode.GrepResult))
                     {
-                        if (!Utils.IsReadOnly(fileNode.GrepResult))
+                        if (!fileNode.GrepResult.IsReadOnly)
                             files.Add(fileNode.GrepResult);
                     }
                 }
@@ -532,7 +531,7 @@ namespace dnGREP.WPF
                 {
                     if (!files.Contains(lineNode.Parent.GrepResult))
                     {
-                        if (!Utils.IsReadOnly(lineNode.Parent.GrepResult))
+                        if (!lineNode.Parent.GrepResult.IsReadOnly)
                             files.Add(lineNode.Parent.GrepResult);
                     }
                 }

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -2056,8 +2056,8 @@ namespace dnGREP.WPF
                     }
                 }
 
-                List<GrepSearchResult> replaceList = ResultsViewModel.GetWritableList()
-                    .Where(sr => sr.Matches.Count != 0).ToList(); // filter out files with errors shown in results tree
+                List<GrepSearchResult> replaceList = ResultsViewModel.
+                    GetWritableFilesWithMatches().ToList(); // filter out files with errors shown in results tree
 
                 bool doReplace = false;
                 if (IsScriptRunning)
@@ -3169,9 +3169,7 @@ namespace dnGREP.WPF
         {
             get
             {
-                var writableFiles = ResultsViewModel.GetWritableList();
-                var hasWritableFiles = writableFiles.Count != 0 &&
-                    writableFiles.SelectMany(m => m.Matches).Any();
+                var hasWritableFiles = ResultsViewModel.GetWritableFilesWithMatches().Any();
 
                 bool enabled = FilesFound && CurrentGrepOperation == GrepOperation.None &&
                         !IsSaveInProgress && !string.IsNullOrEmpty(SearchFor) &&
@@ -3191,11 +3189,9 @@ namespace dnGREP.WPF
             ReplaceButtonToolTip = string.Empty;
             if (!clear && !CanReplace && FilesFound)
             {
-                var writableFiles = ResultsViewModel.GetWritableList();
-                var hasWritableFiles = writableFiles.Count != 0;
-                var hasMatches = writableFiles.SelectMany(m => m.Matches).Any();
+                var hasMatches = ResultsViewModel.GetWritableFilesWithMatches().Any();
 
-                if (!hasWritableFiles)
+                if (!hasMatches)
                 {
                     ReplaceButtonToolTip = Resources.Main_ReplaceTooltip_NoWritableFilesInResults;
                 }

--- a/dnGREP.WPF/ViewModels/ReplaceViewModel.cs
+++ b/dnGREP.WPF/ViewModels/ReplaceViewModel.cs
@@ -157,7 +157,7 @@ namespace dnGREP.WPF
                 string formattedText = TranslationSource.Format(Resources.Replace_FileNumberOfCountName,
                    FileNumber, FileCount, item.FileNameReal, matchStr, lineStr);
 
-                if (Utils.IsReadOnly(item))
+                if (item.IsReadOnly)
                 {
                     formattedText += " " + Resources.Replace_ReadOnly;
                 }
@@ -190,7 +190,7 @@ namespace dnGREP.WPF
                 string formattedText = TranslationSource.Format(Resources.Replace_NumberOfMatchesMarkedForReplacement,
                    replaceStr, matchStr);
 
-                if (Utils.IsReadOnly(item))
+                if (item.IsReadOnly)
                 {
                     formattedText += " " + Resources.Replace_ReadOnly;
                 }


### PR DESCRIPTION
Change to return IEnumerable not list to avoid iterating the whole result set. Move IsReadOnly into class