### PR TITLE
fix: use FileShare.ReadWrite to allow searching in already-opened Office documents

### DIFF
--- a/dnGREP.OpenXmlEngine/GrepEngineOpenXml.cs
+++ b/dnGREP.OpenXmlEngine/GrepEngineOpenXml.cs
@@ -254,7 +254,7 @@ namespace dnGREP.Engines.OpenXml
                 {
                     if (stream == null)
                     {
-                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read);
+                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                         stream = fileStream;
                     }
                     sheets = ExcelReader.ExtractExcelText(stream, pauseCancelToken);
@@ -325,7 +325,7 @@ namespace dnGREP.Engines.OpenXml
                 {
                     if (stream == null)
                     {
-                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read);
+                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                         stream = fileStream;
                     }
                     text = WordReader.ExtractWordText(stream, ApplyStringMap, pauseCancelToken);
@@ -388,7 +388,7 @@ namespace dnGREP.Engines.OpenXml
                 {
                     if (stream == null)
                     {
-                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read);
+                        fileStream = File.Open(documentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                         stream = fileStream;
                     }
                     slides = PowerPointReader.ExtractPowerPointText(stream, ApplyStringMap, pauseCancelToken);
@@ -475,3 +475,4 @@ namespace dnGREP.Engines.OpenXml
         private static partial Regex SheetNameRegex();
     }
 }
+


### PR DESCRIPTION
Use `FileShare.ReadWrite` to allow searching in already-opened OpenXML Office documents (Word .docx, PowerPoint .pptx, Excel .xlsx). Otherwise dnGrep complains about "cannot access the file because it is being used by another process" on these files.

I've tested this works on my local already-opened files, but I don't know if it harms safety/robustness.