### PR TITLE
Improve tab/whitespace rendering and match highlighting

### DIFF
--- a/dnGREP.Common/Utils.cs
+++ b/dnGREP.Common/Utils.cs
@@ -40,6 +40,13 @@ namespace dnGREP.Common
         private static readonly object regexLock = new();
         private static readonly Dictionary<string, Regex> regexCache = [];
 
+        /// <summary>
+        /// The tab size used for whitespace visualization in the results tree
+        /// and the preview window. This size matches (as close as possible)
+        /// the default tab positions for the WPF TextBlock (which can't be changed)
+        /// </summary>
+        public const int WhitespaceTabSize = 7;
+
         static Utils()
         {
             tempFolderName = "dnGrep-temp-" + GetUniqueKey(12);

--- a/dnGREP.OpenXmlEngine/WordReader.cs
+++ b/dnGREP.OpenXmlEngine/WordReader.cs
@@ -43,7 +43,7 @@ namespace dnGREP.Engines.OpenXml
             // Open a given Word document as readonly
             using (WordprocessingDocument doc = WordprocessingDocument.Open(stream, false))
             {
-                var body = doc.MainDocumentPart?.Document.Body;
+                var body = doc.MainDocumentPart?.Document?.Body;
                 var docStyles = doc.MainDocumentPart?.StyleDefinitionsPart?.Styles?
                     .Where(r => r is Style).Select(r => r as Style);
                 var sectionMap = GetSectionMap(body);
@@ -201,7 +201,7 @@ namespace dnGREP.Engines.OpenXml
                         {
                             completedReferences.Add(id);
 
-                            if (headerPart.Header.Descendants<Run>().Any())
+                            if (headerPart?.Header?.Descendants<Run>().Any() == true)
                             {
                                 sb.AppendLine(@"▲───────────");
                                 foreach (Paragraph hp in headerPart.Header.Elements<Paragraph>())
@@ -237,7 +237,7 @@ namespace dnGREP.Engines.OpenXml
                         {
                             completedReferences.Add(id);
 
-                            if (footerPart.Footer.Descendants<Run>().Any())
+                            if (footerPart?.Footer?.Descendants<Run>().Any() == true)
                             {
                                 sb.AppendLine(@"▼───────────");
                                 foreach (Paragraph hp in footerPart.Footer.Elements<Paragraph>())
@@ -295,6 +295,10 @@ namespace dnGREP.Engines.OpenXml
                 if (child is Text text)
                 {
                     sb.Append(text.Text);
+                }
+                else if (child is TabChar)
+                {
+                    sb.Append('\t');
                 }
                 else if (child is NoBreakHyphen)
                 {

--- a/dnGREP.WPF/MVHelpers/PreviewHighlighter.cs
+++ b/dnGREP.WPF/MVHelpers/PreviewHighlighter.cs
@@ -67,11 +67,15 @@ namespace dnGREP.WPF
                 {
                     var grepMatch = lineResult.Matches[i];
 
-                    int startOffset = grepMatch.StartLocation;
-                    // match may include the non-printing newline chars at the end of the line, don't overflow the length
-                    int endOffset = Math.Min(visLine.VisualLength, grepMatch.StartLocation + grepMatch.Length);
+                    // Convert document text offsets to visual columns.
+                    // This accounts for elements like TabTextElement that have
+                    // a visual length (2) different from their document length (1).
+                    int startVC = visLine.GetVisualColumn(grepMatch.StartLocation);
+                    int endVC = Math.Min(visLine.VisualLength,
+                        visLine.GetVisualColumn(Math.Min(grepMatch.StartLocation + grepMatch.Length,
+                            line.Length)));
 
-                    var rects = BackgroundGeometryBuilder.GetRectsFromVisualSegment(textView, visLine, startOffset, endOffset);
+                    var rects = BackgroundGeometryBuilder.GetRectsFromVisualSegment(textView, visLine, startVC, endVC);
                     if (rects.Any())
                     {
                         BackgroundGeometryBuilder geoBuilder = new()

--- a/dnGREP.WPF/Views/PreviewControl.xaml.cs
+++ b/dnGREP.WPF/Views/PreviewControl.xaml.cs
@@ -36,6 +36,8 @@ namespace dnGREP.WPF
 
             textEditor.ShowLineNumbers = false; // using custom line numbers
 
+            textEditor.TextArea.TextView.Options.IndentationSize = Utils.WhitespaceTabSize;
+
             lineNumberMargin = new PreviewLineNumberMargin();
             Line line = (Line)DottedLineMargin.Create();
             textEditor.TextArea.LeftMargins.Insert(0, lineNumberMargin);


### PR DESCRIPTION
- Update whitespace rendering to align tabs/spaces visually, using column tracking and dynamic padding.
- Set text editor IndentationSize to match tab visualization.
- Enhance WordReader to handle TabChar and add null checks for robustness.
- Update match highlighting to use visual columns for accurate alignment.
- Always append newline marker as a separate Run when visualizing whitespace.