### PR TITLE
Add null/empty checks for keys and values in StringMap

### DIFF
--- a/dnGREP.Common/StringMap.cs
+++ b/dnGREP.Common/StringMap.cs
@@ -58,7 +58,10 @@ namespace dnGREP.Common
 
             foreach (var item in map)
             {
-                text = text.Replace(item.Key, item.Value, StringComparison.Ordinal);
+                if (!string.IsNullOrEmpty(item.Key) && item.Value != null)
+                {
+                    text = text.Replace(item.Key, item.Value, StringComparison.Ordinal);
+                }
             }
 
             return text;


### PR DESCRIPTION
Prevent string replacement when map keys are null or empty, or values are null, to avoid runtime errors.