### PR TITLE
Validate keys and values in string map operations

### DIFF
--- a/dnGREP.Common/GrepApplicationSettings.cs
+++ b/dnGREP.Common/GrepApplicationSettings.cs
@@ -979,10 +979,13 @@ namespace dnGREP.Common
                 XElement root = new("keyValuePairArray");
                 foreach (var pair in map)
                 {
-                    var elem = new XElement("keyValuePair");
-                    elem.SetAttributeValue("key", pair.Key);
-                    elem.SetAttributeValue("value", pair.Value);
-                    root.Add(elem);
+                    if (!string.IsNullOrWhiteSpace(pair.Key) && pair.Value != null)
+                    {
+                        var elem = new XElement("keyValuePair");
+                        elem.SetAttributeValue("key", pair.Key);
+                        elem.SetAttributeValue("value", pair.Value);
+                        root.Add(elem);
+                    }
                 }
 
                 string xmlString = root.ToString();
@@ -1003,7 +1006,7 @@ namespace dnGREP.Common
                     foreach (var elem in root.Descendants("keyValuePair"))
                     {
                         if (elem.Attribute("key") is XAttribute keyAttr &&
-                            keyAttr.Value != null &&
+                            !string.IsNullOrEmpty(keyAttr.Value) &&
                             elem.Attribute("value") is XAttribute valueAttr &&
                             valueAttr.Value != null)
                         {

--- a/dnGREP.Common/StringMap.cs
+++ b/dnGREP.Common/StringMap.cs
@@ -16,9 +16,13 @@ namespace dnGREP.Common
             map.Clear();
             foreach (var item in dictionary)
             {
-                map[item.Key] = item.Value;
+                if (!string.IsNullOrEmpty(item.Key))
+                {
+                    map[item.Key] = item.Value;
+                }
             }
         }
+
         public static string Describe(string text)
         {
             if (string.IsNullOrEmpty(text))

--- a/dnGREP.WPF/ViewModels/StringMapViewModel.cs
+++ b/dnGREP.WPF/ViewModels/StringMapViewModel.cs
@@ -41,10 +41,13 @@ namespace dnGREP.WPF
 
             foreach (var item in stringMap.Map)
             {
-                _items.Add(new StringSubstitutionViewModel(this,
-                    item.Key, item.Value, _items.Count));
+                if (!string.IsNullOrEmpty(item.Key) && item.Value != null)
+                {
+                    _items.Add(new StringSubstitutionViewModel(this,
+                        item.Key, item.Value, _items.Count));
 
-                MapKeys.Add(item.Key);
+                    MapKeys.Add(item.Key);
+                }
             }
             MapItems = CollectionViewSource.GetDefaultView(_items);
 
@@ -103,7 +106,10 @@ namespace dnGREP.WPF
 
             foreach (var item in _items.OrderBy(i => i.Ordinal))
             {
-                stringMap.Map.Add(item.MapKey, item.MapValue);
+                if (!string.IsNullOrEmpty(item.MapKey) && item.MapValue != null)
+                {
+                    stringMap.Map.Add(item.MapKey, item.MapValue);
+                }
             }
             GrepSettings.Instance.SaveSubstitutionStrings(stringMap);
 


### PR DESCRIPTION
Add checks to ensure only non-empty, non-null keys (and non-null values) are processed and stored when serializing, deserializing, loading, and saving string maps. This improves data integrity and prevents invalid or incomplete key-value pairs from being handled by the application.