### PR TITLE
Update ComboBox multiline style with max height and scrollbar

### DIFF
--- a/dnGREP.WPF/ThemedControls/ComboBox.xaml
+++ b/dnGREP.WPF/ThemedControls/ComboBox.xaml
@@ -240,6 +240,9 @@
         <Style.Triggers>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(my:MultilineComboBox.AllowMultiline)}" Value="True">
                 <Setter Property="Template" Value="{StaticResource MultilineTemplate}" />
+                <Setter Property="MaxHeight" Value="120" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
             </DataTrigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
When AllowMultiline is enabled, set ComboBox MaxHeight to 120, align it to the top, and enable vertical scrollbar auto-visibility. These changes prevent multiline ComboBoxes from growing endlessly.