### PR TITLE
Better handling of Zip files without a valid signature found

### DIFF
--- a/SevenZip/FileChecker.cs
+++ b/SevenZip/FileChecker.cs
@@ -8,7 +8,7 @@
     /// The signature checker class. Original code by Siddharth Uppal, adapted by Markhor.
     /// </summary>
     /// <remarks>Based on the code at http://blog.somecreativity.com/2008/04/08/how-to-check-if-a-file-is-compressed-in-c/#</remarks>
-    public static class FileChecker
+    internal static class FileChecker
     {
         private const int SIGNATURE_SIZE = 21;
         private const int SFX_SCAN_LENGTH = 256 * 1024;

--- a/SevenZip/FileChecker.cs
+++ b/SevenZip/FileChecker.cs
@@ -8,7 +8,7 @@
     /// The signature checker class. Original code by Siddharth Uppal, adapted by Markhor.
     /// </summary>
     /// <remarks>Based on the code at http://blog.somecreativity.com/2008/04/08/how-to-check-if-a-file-is-compressed-in-c/#</remarks>
-    internal static class FileChecker
+    public static class FileChecker
     {
         private const int SIGNATURE_SIZE = 21;
         private const int SFX_SCAN_LENGTH = 256 * 1024;

--- a/SevenZip/FileChecker.cs
+++ b/SevenZip/FileChecker.cs
@@ -1,4 +1,4 @@
-﻿namespace SevenZip
+namespace SevenZip
 {
     using System;
     using System.IO;
@@ -252,6 +252,32 @@
                     isExecutable = false;
                     return Formats.FormatByFileName(fileName, true);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets the InArchiveFormat for a specific extension.
+        /// </summary>
+        /// <param name="fileName">The archive file name (optional)</param>
+        /// <param name="stream">The stream to identify.</param>
+        /// <param name="offset">The archive beginning offset.</param>
+        /// <param name="isExecutable">True if the original format of the stream is PE; otherwise, false.</param>
+        /// <returns>Corresponding InArchiveFormat.</returns>
+        public static InArchiveFormat CheckSignature(string fileName, Stream stream, out int offset, out bool isExecutable)
+        {
+            try
+            {
+                return CheckSignature(stream, out offset, out isExecutable);
+            }
+            catch (ArgumentException)
+            {
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    offset = 0;
+                    isExecutable = false;
+                    return Formats.FormatByFileName(fileName, true);
+                }
+                throw;
             }
         }
 

--- a/SevenZip/SevenZipExtractor.cs
+++ b/SevenZip/SevenZipExtractor.cs
@@ -103,14 +103,15 @@ namespace SevenZip
         /// </summary>
         /// <param name="stream">The stream to read the archive from.</param>
         /// <param name="leaveOpen">true to leave the wrapped stream open after the ArchiveEmulationStreamProxy object is disposed; otherwise, false.</param>
-        private void Init(Stream stream, bool leaveOpen = false)
+        /// <param name="archiveFullName">The archive file name.</param>
+        private void Init(Stream stream, bool leaveOpen = false, string archiveFullName = null)
         {
             ValidateStream(stream);
             var isExecutable = false;
 
             if ((int)_format == -1)
             {
-                _format = FileChecker.CheckSignature(stream, out _offset, out isExecutable);
+                _format = FileChecker.CheckSignature(archiveFullName, stream, out _offset, out isExecutable);
             }
 
             PreserveDirectoryStructure = true;
@@ -236,6 +237,18 @@ namespace SevenZip
             : base(password)
         {
             Init(archiveStream, leaveOpen);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of SevenZipExtractor class.
+        /// </summary>
+        /// <param name="archiveFullName">The archive full file name.</param>
+        /// <param name="archiveStream">The stream to read the archive from.</param>
+        /// <param name="password">Password for an encrypted archive.</param>
+        /// <param name="leaveOpen">true to leave the wrapped stream open after the ArchiveEmulationStreamProxy object is disposed; otherwise, false.</param>
+        public SevenZipExtractor(string archiveFullName, Stream archiveStream, string password, bool leaveOpen = false)
+        {
+            Init(archiveStream, leaveOpen, archiveFullName);
         }
 
         /// <summary>

--- a/dnGREP.Engines/ArchiveEngine.cs
+++ b/dnGREP.Engines/ArchiveEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -138,7 +138,7 @@ namespace dnGREP.Engines
             string password, string searchPattern, SearchType searchType, GrepSearchOption searchOptions,
             Encoding encoding, PauseCancelToken pauseCancelToken)
         {
-            using SevenZipExtractor extractor = new(input, password, true);
+            using SevenZipExtractor extractor = new(fileName, input, password, true);
             foreach (var fileInfo in extractor.ArchiveFileData)
             {
                 FileData fileData = new(fileName, fileInfo);

--- a/dnGREP.Engines/ArchiveEngine.cs
+++ b/dnGREP.Engines/ArchiveEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -135,10 +135,24 @@ namespace dnGREP.Engines
         }
 
         private IEnumerable<List<GrepSearchResult>> SearchInsideArchive(Stream input, string fileName,
-            string password, string searchPattern, SearchType searchType, GrepSearchOption searchOptions,
-            Encoding encoding, PauseCancelToken pauseCancelToken)
+    string password, string searchPattern, SearchType searchType, GrepSearchOption searchOptions,
+    Encoding encoding, PauseCancelToken pauseCancelToken)
         {
-            using SevenZipExtractor extractor = new(input, password, true);
+            InArchiveFormat format;
+            try
+            {
+                format = FileChecker.CheckSignature(input, out _, out _);
+            }
+            catch (ArgumentException)
+            {
+                // Stream signature not recognized — fall back to the file name extension,
+                // mirroring the behavior of the SevenZipExtractor(string) constructor.
+                format = Formats.FormatByFileName(fileName, true);
+            }
+
+            using SevenZipExtractor extractor = string.IsNullOrEmpty(password)
+                ? new SevenZipExtractor(input, format, true)
+                : new SevenZipExtractor(input, password, format, true);
             foreach (var fileInfo in extractor.ArchiveFileData)
             {
                 FileData fileData = new(fileName, fileInfo);

--- a/dnGREP.Engines/ArchiveEngine.cs
+++ b/dnGREP.Engines/ArchiveEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -135,24 +135,10 @@ namespace dnGREP.Engines
         }
 
         private IEnumerable<List<GrepSearchResult>> SearchInsideArchive(Stream input, string fileName,
-    string password, string searchPattern, SearchType searchType, GrepSearchOption searchOptions,
-    Encoding encoding, PauseCancelToken pauseCancelToken)
+            string password, string searchPattern, SearchType searchType, GrepSearchOption searchOptions,
+            Encoding encoding, PauseCancelToken pauseCancelToken)
         {
-            InArchiveFormat format;
-            try
-            {
-                format = FileChecker.CheckSignature(input, out _, out _);
-            }
-            catch (ArgumentException)
-            {
-                // Stream signature not recognized — fall back to the file name extension,
-                // mirroring the behavior of the SevenZipExtractor(string) constructor.
-                format = Formats.FormatByFileName(fileName, true);
-            }
-
-            using SevenZipExtractor extractor = string.IsNullOrEmpty(password)
-                ? new SevenZipExtractor(input, format, true)
-                : new SevenZipExtractor(input, password, format, true);
+            using SevenZipExtractor extractor = new(input, password, true);
             foreach (var fileInfo in extractor.ArchiveFileData)
             {
                 FileData fileData = new(fileName, fileInfo);


### PR DESCRIPTION
The goal of the PR is to fix this error in Grep_Error_Log.xml

<logevent time="2026-05-18 12:57:54.2459" level="Error" logger="dnGREP.Engines.ArchiveEngine">
  <message>Failed to search inside archive &apos;C:\PROJECTS\client.zip&apos;</message>
  <exception>System.ArgumentException: The stream is invalid or no corresponding signature was found.
   at SevenZip.FileChecker.CheckSignature(Stream stream, Int32&amp; offset, Boolean&amp; isExecutable) in C:\Users\tbernard\source\repos\dnGrep\SevenZip\FileChecker.cs:line 230
   at SevenZip.SevenZipExtractor.Init(Stream stream, Boolean leaveOpen) in C:\Users\tbernard\source\repos\dnGrep\SevenZip\SevenZipExtractor.cs:line 113
   at SevenZip.SevenZipExtractor..ctor(Stream archiveStream, String password, Boolean leaveOpen) in C:\Users\tbernard\source\repos\dnGrep\SevenZip\SevenZipExtractor.cs:line 238
   at dnGREP.Engines.ArchiveEngine.SearchInsideArchive(Stream input, String fileName, String password, String searchPattern, SearchType searchType, GrepSearchOption searchOptions, Encoding encoding, PauseCancelToken pauseCancelToken)+MoveNext() in C:\Users\tbernard\source\repos\dnGrep\dnGREP.Engines\ArchiveEngine.cs:line 141
   at dnGREP.Engines.ArchiveEngine.Search(Stream input, String fileName, String password, String searchPattern, SearchType searchType, GrepSearchOption searchOptions, Encoding encoding, PauseCancelToken pauseCancelToken)+MoveNext() in C:\Users\tbernard\source\repos\dnGrep\dnGREP.Engines\ArchiveEngine.cs:line 108</exception>
</logevent>

What changed and why
Before
new SevenZipExtractor(input, password, true) — format guessed from stream only
After
Format is resolved first with the same try/catch fallback to extension that the string constructor uses

Before
ArgumentException propagates when no signature matches
After
Falls back to Formats.FormatByFileName(fileName, true) using the known fileName

Before
Uses the (Stream, string, bool) overload which calls CheckSignature(Stream) internally
After
Uses the (Stream, InArchiveFormat, bool) / (Stream, string, InArchiveFormat, bool) overload which skips CheckSignature entirely