### PR TITLE
1478 details scrollbar

### DIFF
--- a/dnGREP.WPF/MVHelpers/LazyResultsList.cs
+++ b/dnGREP.WPF/MVHelpers/LazyResultsList.cs
@@ -51,11 +51,9 @@ namespace dnGREP.WPF.MVHelpers
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
                 GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter));
 
-            FormatAndLoadLines(linesWithContext);
-
             IsLoaded = true;
             IsLoading = false;
-            LoadFinished?.Invoke(this, EventArgs.Empty);
+            FormatAndLoadLines(linesWithContext);
             return true;
         }
 
@@ -74,11 +72,9 @@ namespace dnGREP.WPF.MVHelpers
                 return list;
             });
 
-            FormatAndLoadLines(linesWithContext);
-
             IsLoaded = true;
             IsLoading = false;
-            LoadFinished?.Invoke(this, EventArgs.Empty);
+            FormatAndLoadLines(linesWithContext);
             return true;
         }
 
@@ -125,6 +121,7 @@ namespace dnGREP.WPF.MVHelpers
                     {
                         Add(l);
                     }
+                    LoadFinished?.Invoke(this, EventArgs.Empty);
                 }
             ));
         }

--- a/dnGREP.WPF/MVHelpers/LazyResultsList.cs
+++ b/dnGREP.WPF/MVHelpers/LazyResultsList.cs
@@ -46,21 +46,23 @@ namespace dnGREP.WPF.MVHelpers
                 return false;
 
             IsLoading = true;
-
-            List<GrepLine> linesWithContext = result.GetLinesWithContext(
-                GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
-                GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter));
-
-            IsLoaded = true;
-            IsLoading = false;
             try
             {
+                List<GrepLine> linesWithContext = result.GetLinesWithContext(
+                    GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
+                    GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter));
+
+                IsLoaded = true;
                 FormatAndLoadLines(linesWithContext);
             }
             catch
             {
                 IsLoaded = false;
                 throw;
+            }
+            finally
+            {
+                IsLoading = false;
             }
             return true;
         }
@@ -71,25 +73,27 @@ namespace dnGREP.WPF.MVHelpers
                 return false;
 
             IsLoading = true;
-
-            List<GrepLine> linesWithContext = await Task.Run(() =>
-            {
-                List<GrepLine> list = result.GetLinesWithContext(
-                    GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
-                    GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter));
-                return list;
-            });
-
-            IsLoaded = true;
-            IsLoading = false;
             try
             {
+                List<GrepLine> linesWithContext = await Task.Run(() =>
+                {
+                    List<GrepLine> list = result.GetLinesWithContext(
+                        GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesBefore),
+                        GrepSettings.Instance.Get<int>(GrepSettings.Key.ContextLinesAfter));
+                    return list;
+                });
+
+                IsLoaded = true;
                 FormatAndLoadLines(linesWithContext);
             }
             catch
             {
                 IsLoaded = false;
                 throw;
+            }
+            finally
+            {
+                IsLoading = false;
             }
             return true;
         }

--- a/dnGREP.WPF/MVHelpers/LazyResultsList.cs
+++ b/dnGREP.WPF/MVHelpers/LazyResultsList.cs
@@ -53,7 +53,15 @@ namespace dnGREP.WPF.MVHelpers
 
             IsLoaded = true;
             IsLoading = false;
-            FormatAndLoadLines(linesWithContext);
+            try
+            {
+                FormatAndLoadLines(linesWithContext);
+            }
+            catch
+            {
+                IsLoaded = false;
+                throw;
+            }
             return true;
         }
 
@@ -74,7 +82,15 @@ namespace dnGREP.WPF.MVHelpers
 
             IsLoaded = true;
             IsLoading = false;
-            FormatAndLoadLines(linesWithContext);
+            try
+            {
+                FormatAndLoadLines(linesWithContext);
+            }
+            catch
+            {
+                IsLoaded = false;
+                throw;
+            }
             return true;
         }
 

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml
@@ -77,7 +77,7 @@
                                           MouseDoubleClick="TreeView_MouseDoubleClick" 
                                           MouseUp="TreeView_MouseUp"
                                           PreviewMouseDoubleClick="TreeView_PreviewMouseDoubleClick"
-                                          ScrollViewer.HorizontalScrollBarVisibility="{Binding Path=WrapText, Converter={StaticResource BoolToScollBarVisibilityConverter}}">
+                                          ScrollViewer.HorizontalScrollBarVisibility="Auto">
                 <TreeView.ItemsPanel>
                     <ItemsPanelTemplate>
                         <Controls:MyVirtualizingStackPanel/>
@@ -96,7 +96,7 @@
                                        Height="16" Source="{Binding Icon}" />
                                 <TextBlock Grid.Column="1" 
                                            Margin="6,0,0,0"
-                                           TextWrapping="{Binding WrapText, Converter={StaticResource BoolToTextWrappingConverter}}">
+                                           TextWrapping="NoWrap">
                                     <Run Text="{Binding FilePath}"/><Run Text="{Binding FileName}" FontWeight="{Binding FileNameFontWeight}"/> <Run Text="{Binding FileInfo}"/>
                                     <TextBlock.ToolTip>
                                         <ToolTip  Visibility="{Binding ShowFileInfoTooltips, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -145,14 +145,12 @@
                                 <TextBlock Grid.Column="{Binding DataContext.PathColumnIndex, RelativeSource={RelativeSource AncestorType={x:Type TreeView}}}" 
                                            Margin="3,0"
                                            Text="{Binding FilePath}"
-                                           TextTrimming="CharacterEllipsis"
-                                           TextWrapping="{Binding WrapText, Converter={StaticResource BoolToTextWrappingConverter}}"/>
+                                           TextTrimming="CharacterEllipsis"/>
                                 <TextBlock Grid.Column="{Binding DataContext.NameColumnIndex, RelativeSource={RelativeSource AncestorType={x:Type TreeView}}}" 
                                            Margin="3,0"
                                            Text="{Binding FileName}"
                                            FontWeight="{Binding FileNameFontWeight}"
-                                           TextTrimming="CharacterEllipsis"
-                                           TextWrapping="{Binding WrapText, Converter={StaticResource BoolToTextWrappingConverter}}">
+                                           TextTrimming="CharacterEllipsis">
                                     <TextBlock.ToolTip>
                                         <ToolTip  Visibility="{Binding ShowFileInfoTooltips, Converter={StaticResource BooleanToVisibilityConverter}}">
                                             <StackPanel Orientation="Vertical">

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml
@@ -14,7 +14,6 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <my:BoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible" />
-        <my:BoolToScrollBarVisibilityConverter x:Key="BoolToScollBarVisibilityConverter"/>
         <my:BoolToTextWrappingConverter x:Key="BoolToTextWrappingConverter"/>
         <my:BoolToCheckConverter x:Key="BoolToCheckConverter"/>
         <my:BooleanAndConverter x:Key="BooleanAndConverter"/>

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -11,7 +11,6 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Markup;
 using System.Windows.Media;
-using System.Windows.Threading;
 using dnGREP.Common;
 using dnGREP.Localization;
 using Res = dnGREP.Localization.Properties.Resources;
@@ -28,8 +27,6 @@ namespace dnGREP.WPF.UserControls
         private bool skipScrollOnExpand;
         private bool inNextPrevious;
         private bool stickyScrollEnabled;
-        private readonly DispatcherTimer wrapWidthTimer;
-        private bool wrapWidthUpdatePending;
 
         public GridViewColumnCollection TreeListViewColumns { get; }
 
@@ -83,18 +80,6 @@ namespace dnGREP.WPF.UserControls
 
             InitializeComponent();
             DataContextChanged += ResultsTree_DataContextChanged;
-
-            wrapWidthTimer = new DispatcherTimer(DispatcherPriority.Background)
-            {
-                Interval = TimeSpan.FromMilliseconds(10)
-            };
-            wrapWidthTimer.Tick += (s, e) =>
-            {
-                wrapWidthTimer.Stop();
-                wrapWidthUpdatePending = false;
-                if (DataContext is GrepSearchResultsViewModel vm)
-                    UpdateWrapWidth(vm);
-            };
 
             TranslationSource.Instance.CurrentCultureChanged += UpdateColumnHeaders;
 
@@ -1677,15 +1662,7 @@ namespace dnGREP.WPF.UserControls
             {
                 if (e.ViewportWidthChange != 0 && DataContext is GrepSearchResultsViewModel vm)
                 {
-                    if (!wrapWidthUpdatePending)
-                    {
-                        // Throttle: apply immediately, then suppress further updates
-                        // until the timer fires to catch the final resize value.
-                        wrapWidthUpdatePending = true;
-                        UpdateWrapWidth(vm);
-                        wrapWidthTimer.Stop();
-                        wrapWidthTimer.Start();
-                    }
+                    UpdateWrapWidth(vm);
                 }
 
                 if (e.HorizontalChange != 0 || e.ExtentWidthChange != 0)

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Markup;
 using System.Windows.Media;
+using System.Windows.Threading;
 using dnGREP.Common;
 using dnGREP.Localization;
 using Res = dnGREP.Localization.Properties.Resources;
@@ -27,6 +28,8 @@ namespace dnGREP.WPF.UserControls
         private bool skipScrollOnExpand;
         private bool inNextPrevious;
         private bool stickyScrollEnabled;
+        private readonly DispatcherTimer wrapWidthTimer;
+        private bool wrapWidthUpdatePending;
 
         public GridViewColumnCollection TreeListViewColumns { get; }
 
@@ -80,6 +83,18 @@ namespace dnGREP.WPF.UserControls
 
             InitializeComponent();
             DataContextChanged += ResultsTree_DataContextChanged;
+
+            wrapWidthTimer = new DispatcherTimer(DispatcherPriority.Background)
+            {
+                Interval = TimeSpan.FromMilliseconds(10)
+            };
+            wrapWidthTimer.Tick += (s, e) =>
+            {
+                wrapWidthTimer.Stop();
+                wrapWidthUpdatePending = false;
+                if (DataContext is GrepSearchResultsViewModel vm)
+                    UpdateWrapWidth(vm);
+            };
 
             TranslationSource.Instance.CurrentCultureChanged += UpdateColumnHeaders;
 
@@ -1653,7 +1668,15 @@ namespace dnGREP.WPF.UserControls
             {
                 if (e.ViewportWidthChange != 0 && DataContext is GrepSearchResultsViewModel vm)
                 {
-                    UpdateWrapWidth(vm);
+                    if (!wrapWidthUpdatePending)
+                    {
+                        // Throttle: apply immediately, then suppress further updates
+                        // until the timer fires to catch the final resize value.
+                        wrapWidthUpdatePending = true;
+                        UpdateWrapWidth(vm);
+                        wrapWidthTimer.Stop();
+                        wrapWidthTimer.Start();
+                    }
                 }
 
                 if (e.HorizontalChange != 0 || e.ExtentWidthChange != 0)

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -44,6 +44,9 @@ namespace dnGREP.WPF.UserControls
         // Default column order and widths
         private static readonly double[] DefaultColumnWidths = [22, 150, 200, 200, 100, 100, 100, 160, 100];
 
+        // Minimum column widths by logical column id
+        private static readonly double[] MinColumnWidths = [22, 30, 30, 30, 30, 30, 30, 30, 30];
+
         // Map from GridViewColumn to its logical column id
         private readonly Dictionary<GridViewColumn, int> columnIds = [];
 
@@ -92,7 +95,20 @@ namespace dnGREP.WPF.UserControls
 
             foreach (var column in TreeListViewColumns)
             {
-                widthDescriptor?.AddValueChanged(column, (s, e) => OnColumnLayoutChanged());
+                widthDescriptor?.AddValueChanged(column, (s, e) =>
+                {
+                    if (s is GridViewColumn col)
+                    {
+                        int id = GetColumnId(col);
+                        double minWidth = id >= 0 && id < MinColumnWidths.Length ? MinColumnWidths[id] : 20;
+                        if (col.Width < minWidth)
+                        {
+                            col.Width = minWidth;
+                            return; // setting Width fires the event again; skip this pass
+                        }
+                    }
+                    OnColumnLayoutChanged();
+                });
             }
 
             // Listen for column reorder (Move action in the collection)

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -150,6 +150,7 @@ namespace dnGREP.WPF.UserControls
                 if (treeView.Template.FindName("_tv_scrollviewer_", treeView) is ScrollViewer scrollViewer)
                 {
                     treeScrollViewer = scrollViewer;
+                    scrollViewer.ScrollChanged -= ScrollViewer_ScrollChanged;
                     scrollViewer.ScrollChanged += ScrollViewer_ScrollChanged;
                 }
 
@@ -244,7 +245,9 @@ namespace dnGREP.WPF.UserControls
                     {
                         if (columnById.TryGetValue(order[i], out var col))
                         {
-                            col.Width = widths[i];
+                            int id = order[i];
+                            double minWidth = id >= 0 && id < MinColumnWidths.Length ? MinColumnWidths[id] : 20;
+                            col.Width = Math.Max(widths[i], minWidth);
                         }
                     }
 

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -123,6 +123,7 @@ namespace dnGREP.WPF.UserControls
             treeView.PreviewTouchDown += TreeView_PreviewTouchDown;
             treeView.PreviewTouchMove += TreeView_PreviewTouchMove;
             treeView.PreviewTouchUp += TreeView_PreviewTouchUp;
+            treeView.SelectedItemChanged += TreeView_SelectedItemChanged;
 
             GrepSearchResultsViewModel.SearchResultsMessenger.Register("FormattedLinesLoaded", ScrollExpandedItemToTop);
 
@@ -1603,6 +1604,47 @@ namespace dnGREP.WPF.UserControls
         #endregion
 
         #region Sticky Scroll
+
+        private void TreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (!stickyScrollEnabled || treeScrollViewer == null || contextRoot.Visibility != Visibility.Visible)
+                return;
+
+            if (e.NewValue is not FormattedGrepLine)
+                return;
+
+            // BringIntoView runs before SelectedItemChanged fires, so we need to defer
+            // the check until after layout has updated.
+            Dispatcher.InvokeAsync(() =>
+            {
+                if (treeScrollViewer == null || contextRoot.Visibility != Visibility.Visible)
+                    return;
+
+                if (treeView.SelectedItem is not FormattedGrepLine line)
+                    return;
+
+                var parentResult = line.Parent;
+                if (treeView.ItemContainerGenerator.ContainerFromItem(parentResult) is not TreeViewItem parentTvi)
+                    return;
+
+                if (parentTvi.ItemContainerGenerator.ContainerFromItem(line) is not TreeViewItem lineTvi)
+                    return;
+
+                // Get the position of the selected item relative to the treeView
+                var itemBounds = lineTvi.TransformToAncestor(treeView).TransformBounds(
+                    new Rect(0, 0, lineTvi.ActualWidth, lineTvi.ActualHeight));
+
+                // Get the height of the sticky context overlay
+                double contextHeight = contextRoot.ActualHeight;
+
+                // If the item's top is hidden behind the context overlay, scroll up enough to reveal it
+                if (itemBounds.Top < contextHeight)
+                {
+                    treeScrollViewer.ScrollToVerticalOffset(
+                        treeScrollViewer.VerticalOffset + itemBounds.Top - contextHeight);
+                }
+            }, System.Windows.Threading.DispatcherPriority.Loaded);
+        }
 
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -23,6 +23,7 @@ namespace dnGREP.WPF.UserControls
     public partial class ResultsTree : UserControl, INameScope
     {
         private GrepSearchResultsViewModel? viewModel;
+        private ScrollViewer? treeScrollViewer;
         private bool skipScrollOnExpand;
         private bool inNextPrevious;
         private bool stickyScrollEnabled;
@@ -116,6 +117,7 @@ namespace dnGREP.WPF.UserControls
 
                 if (treeView.Template.FindName("_tv_scrollviewer_", treeView) is ScrollViewer scrollViewer)
                 {
+                    treeScrollViewer = scrollViewer;
                     scrollViewer.ScrollChanged += ScrollViewer_ScrollChanged;
                 }
 
@@ -123,6 +125,10 @@ namespace dnGREP.WPF.UserControls
                 {
                     vm.PropertyChanged += (s, e) =>
                     {
+                        if (e.PropertyName == nameof(GrepSearchResultsViewModel.WrapText))
+                        {
+                            UpdateWrapWidth(vm);
+                        }
                         if (e.PropertyName == nameof(GrepSearchResultsViewModel.StickyScrollEnabled))
                         {
                             stickyScrollEnabled = GrepSearchResultsViewModel.StickyScrollEnabled;
@@ -1586,6 +1592,11 @@ namespace dnGREP.WPF.UserControls
         {
             if (sender is ScrollViewer sv)
             {
+                if (e.ViewportWidthChange != 0 && DataContext is GrepSearchResultsViewModel vm)
+                {
+                    UpdateWrapWidth(vm);
+                }
+
                 if (e.HorizontalChange != 0 || e.ExtentWidthChange != 0)
                 {
                     // Ensure header and context have enough width to scroll the full extent
@@ -1602,6 +1613,22 @@ namespace dnGREP.WPF.UserControls
             {
                 ResetContextItemVisible();
             }
+        }
+
+        private void UpdateWrapWidth(GrepSearchResultsViewModel vm)
+        {
+            // Subtract the TreeViewItem indent offsets so the pixel column width
+            // fits exactly within the viewport:
+            //   19px  parent expander column (MinWidth)
+            //    1px  parent Border left border thickness
+            //    1px  parent Border left padding
+            //    1px  child Border left border thickness
+            //    6px  InlineTextBlock left margin
+            //   12px  breathing room to ensure the right most char is in the visible area
+            const double treeIndent = 40;
+            vm.WrapWidth = (vm.WrapText && treeScrollViewer != null)
+                ? Math.Max(1, treeScrollViewer.ViewportWidth - treeIndent)
+                : 0;
         }
 
         private void ResetContextItemVisible()

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -1814,16 +1814,16 @@ namespace dnGREP.WPF.UserControls
                             }
                             else
                             {
-                                    foreach (FormattedGrepLine childNode in node.Children.Cast<FormattedGrepLine>())
+                                foreach (FormattedGrepLine childNode in node.Children.Cast<FormattedGrepLine>())
+                                {
+                                    if (container.ItemContainerGenerator.ContainerFromItem(childNode) is TreeViewItem treeViewItem &&
+                                        IsChildVisible(treeView, treeViewItem))
                                     {
-                                        if (container.ItemContainerGenerator.ContainerFromItem(childNode) is TreeViewItem treeViewItem &&
-                                            IsChildVisible(treeView, treeViewItem))
-                                        {
-                                            return node;
-                                        }
+                                        return node;
                                     }
                                 }
                             }
+                        }
                     }
                 }
             }

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -157,28 +157,34 @@ namespace dnGREP.WPF.UserControls
                 if (DataContext is GrepSearchResultsViewModel vm)
                 {
                     UpdateWrapWidth(vm);
-                    vm.PropertyChanged += (s, e) =>
-                    {
-                        if (e.PropertyName == nameof(GrepSearchResultsViewModel.WrapText))
-                        {
-                            UpdateWrapWidth(vm);
-                        }
-                        if (e.PropertyName == nameof(GrepSearchResultsViewModel.StickyScrollEnabled))
-                        {
-                            stickyScrollEnabled = GrepSearchResultsViewModel.StickyScrollEnabled;
-                            if (stickyScrollEnabled)
-                            {
-                                ResetContextItemVisible();
-                            }
-                            else
-                            {
-                                vm.ContextGrepResult = null;
-                                vm.ContextGrepResultVisible = false;
-                            }
-                        }
-                    };
+                    vm.PropertyChanged -= ViewModel_PropertyChanged;
+                    vm.PropertyChanged += ViewModel_PropertyChanged;
                 }
             };
+        }
+
+        private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (DataContext is GrepSearchResultsViewModel vm)
+            {
+                if (e.PropertyName == nameof(GrepSearchResultsViewModel.WrapText))
+                {
+                    UpdateWrapWidth(vm);
+                }
+                if (e.PropertyName == nameof(GrepSearchResultsViewModel.StickyScrollEnabled))
+                {
+                    stickyScrollEnabled = GrepSearchResultsViewModel.StickyScrollEnabled;
+                    if (stickyScrollEnabled)
+                    {
+                        ResetContextItemVisible();
+                    }
+                    else
+                    {
+                        vm.ContextGrepResult = null;
+                        vm.ContextGrepResultVisible = false;
+                    }
+                }
+            }
         }
 
         private void UpdateColumnHeaders(object? sender, EventArgs e)

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -140,6 +140,7 @@ namespace dnGREP.WPF.UserControls
 
                 if (DataContext is GrepSearchResultsViewModel vm)
                 {
+                    UpdateWrapWidth(vm);
                     vm.PropertyChanged += (s, e) =>
                     {
                         if (e.PropertyName == nameof(GrepSearchResultsViewModel.WrapText))
@@ -1744,6 +1745,28 @@ namespace dnGREP.WPF.UserControls
             return visible;
         }
 
+        /// <summary>
+        /// Returns true if a child TreeViewItem intersects the viewport, i.e. any part of it
+        /// is visible. Unlike <see cref="IsUserVisible"/> this does not require the item to fit
+        /// fully within the viewport, which is necessary for tall wrapped lines.
+        /// </summary>
+        private static bool IsChildVisible(TreeView treeView, TreeViewItem treeViewItem)
+        {
+            if (!treeViewItem.IsVisible)
+                return false;
+
+            var header = GetHeaderControl(treeViewItem);
+            Rect tviRect = header != null
+                ? new(0.0, 0.0, header.ActualWidth, header.ActualHeight)
+                : new(0.0, 0.0, treeViewItem.ActualWidth, treeViewItem.ActualHeight);
+
+            Rect itemBounds = treeViewItem.TransformToAncestor(treeView).TransformBounds(tviRect);
+            Rect containerRect = new(0.0, 0.0, treeView.ActualWidth, treeView.ActualHeight);
+            // Intersect: item is visible if its bottom is below the viewport top
+            // AND its top is above the viewport bottom.
+            return itemBounds.Bottom > containerRect.Top && itemBounds.Top < containerRect.Bottom;
+        }
+
         private static FrameworkElement GetHeaderControl(TreeViewItem item)
         {
             return (FrameworkElement)item.Template.FindName("PART_Header", item);
@@ -1765,16 +1788,16 @@ namespace dnGREP.WPF.UserControls
                             }
                             else
                             {
-                                foreach (FormattedGrepLine childNode in node.Children.Cast<FormattedGrepLine>())
-                                {
-                                    if (container.ItemContainerGenerator.ContainerFromItem(childNode) is TreeViewItem treeViewItem &&
-                                        IsUserVisible(treeView, treeViewItem))
+                                    foreach (FormattedGrepLine childNode in node.Children.Cast<FormattedGrepLine>())
                                     {
-                                        return node;
+                                        if (container.ItemContainerGenerator.ContainerFromItem(childNode) is TreeViewItem treeViewItem &&
+                                            IsChildVisible(treeView, treeViewItem))
+                                        {
+                                            return node;
+                                        }
                                     }
                                 }
                             }
-                        }
                     }
                 }
             }

--- a/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
+++ b/dnGREP.WPF/UserControls/ResultsTree.xaml.cs
@@ -1712,7 +1712,7 @@ namespace dnGREP.WPF.UserControls
             //   12px  breathing room to ensure the right most char is in the visible area
             const double treeIndent = 40;
             vm.WrapWidth = (vm.WrapText && treeScrollViewer != null)
-                ? Math.Max(1, treeScrollViewer.ViewportWidth - treeIndent)
+                ? Math.Max(1, Math.Round(treeScrollViewer.ViewportWidth - treeIndent, 0))
                 : 0;
         }
 

--- a/dnGREP.WPF/ViewModels/FormattedGrepLine.cs
+++ b/dnGREP.WPF/ViewModels/FormattedGrepLine.cs
@@ -29,6 +29,7 @@ namespace dnGREP.WPF
             LineNumberColumnWidth = initialColumnWidth;
             IsSectionBreak = breakSection;
             WrapText = Parent.WrapText;
+            WrapWidth = Parent.WrapWidth;
             ViewWhitespace = Parent.ViewWhitespace;
             int lineSize = GrepSettings.Instance.Get<int>(GrepSettings.Key.HexResultByteLength);
             var pdfNumberStyle = GrepSettings.Instance.Get<PdfNumberType>(GrepSettings.Key.PdfNumberStyle);
@@ -93,6 +94,7 @@ namespace dnGREP.WPF
                     ResultColumn2Width = "0";
                     ResultColumn1SharedSizeGroupName = null;
                 }
+                UpdateResultColumn1Width();
             }
         }
 
@@ -147,9 +149,30 @@ namespace dnGREP.WPF
         partial void OnWrapTextChanged(bool value)
         {
             MaxLineLength = value ? 10000 : 500;
+            UpdateResultColumn1Width();
         }
 
         public int MaxLineLength { get; private set; } = 500;
+
+        [ObservableProperty]
+        private double wrapWidth;
+        partial void OnWrapWidthChanged(double value)
+        {
+            UpdateResultColumn1Width();
+        }
+
+        private void UpdateResultColumn1Width()
+        {
+            if (WrapText && WrapWidth > 0)
+            {
+                double pixelWidth = Math.Max(1, WrapWidth - LineNumberColumnWidth);
+                ResultColumn1Width = pixelWidth.ToString("F0", System.Globalization.CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                ResultColumn1Width = IsHexData ? "Auto" : "*";
+            }
+        }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(FormattedText))]

--- a/dnGREP.WPF/ViewModels/FormattedGrepLine.cs
+++ b/dnGREP.WPF/ViewModels/FormattedGrepLine.cs
@@ -130,6 +130,10 @@ namespace dnGREP.WPF
 
         [ObservableProperty]
         private int lineNumberColumnWidth = 30;
+        partial void OnLineNumberColumnWidthChanged(int value)
+        {
+            UpdateResultColumn1Width();
+        }
 
         void Parent_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {

--- a/dnGREP.WPF/ViewModels/FormattedGrepResult.cs
+++ b/dnGREP.WPF/ViewModels/FormattedGrepResult.cs
@@ -246,6 +246,14 @@ namespace dnGREP.WPF
         {
             IsLoading = false;
 
+            if (WrapText && WrapWidth > 0)
+            {
+                foreach (var item in FormattedLines)
+                {
+                    item.WrapWidth = WrapWidth;
+                }
+            }
+
             GrepSearchResultsViewModel.SearchResultsMessenger.NotifyColleagues("FormattedLinesLoaded");
         }
 
@@ -266,6 +274,19 @@ namespace dnGREP.WPF
                 foreach (var item in FormattedLines)
                 {
                     item.WrapText = value;
+                }
+            }
+        }
+
+        [ObservableProperty]
+        private double wrapWidth;
+        partial void OnWrapWidthChanged(double value)
+        {
+            if (FormattedLines != null)
+            {
+                foreach (var item in FormattedLines)
+                {
+                    item.WrapWidth = value;
                 }
             }
         }

--- a/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
@@ -370,7 +370,8 @@ namespace dnGREP.WPF
                 {
                     var fmtResult = new FormattedGrepResult(r, FolderPath, ViewWhitespace)
                     {
-                        WrapText = WrapText
+                        WrapText = WrapText,
+                        WrapWidth = WrapWidth
                     };
                     SearchResults.Add(fmtResult);
 

--- a/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/GrepSearchResultsViewModel.cs
@@ -642,6 +642,16 @@ namespace dnGREP.WPF
         }
 
         [ObservableProperty]
+        private double wrapWidth;
+        partial void OnWrapWidthChanged(double value)
+        {
+            foreach (var item in SearchResults)
+            {
+                item.WrapWidth = value;
+            }
+        }
+
+        [ObservableProperty]
         private bool viewWhitespace;
         partial void OnViewWhitespaceChanged(bool value)
         {


### PR DESCRIPTION
Refactored `ResultsTree` to fix text wrapping and scrolling:
- Replaced `TextWrapping` bindings with fixed `NoWrap` values.
- Changed `ScrollViewer.HorizontalScrollBarVisibility` to `Auto`.
- Introduced `treeScrollViewer` and `UpdateWrapWidth` for dynamic wrap width calculation.
- Added `WrapWidth` property to `GrepSearchResultsViewModel`, `FormattedGrepResult`, and `FormattedGrepLine` for consistent wrapping behavior.
- Enhanced responsiveness to viewport changes by dynamically adjusting wrap width during scrolling.

Added a `MinColumnWidths` array to define minimum allowable
widths for each logical column in `ResultsTree.xaml.cs`.
Updated the `AddValueChanged` event handler for
`GridViewColumn.WidthProperty` to enforce these minimums,
preventing columns from being resized too narrowly.

The handler adjusts column widths below the minimum and skips
recursive event calls. This prevents the user from setting the width
to zero and not be able to restore the column.

Fix element selection with sticky scroll for TreeView selection
Implemented the `TreeView_SelectedItemChanged` method to ensure
that selected items in the `treeView` remain visible when a
sticky context overlay is present. The method adjusts the
scroll position dynamically to prevent the selected item from
being obscured.

Added an event handler for the `SelectedItemChanged` event of
the `treeView` control. The logic uses deferred execution with
`Dispatcher.InvokeAsync` to ensure layout updates are complete
before scrolling adjustments are made.

Included checks to ensure the feature only executes when the
sticky scroll is enabled, the `treeScrollViewer` is available,
and the `contextRoot` is visible.