### PR TITLE
Add ToggleDetailsViewCommand to MainViewModel

### DIFF
--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -108,6 +108,7 @@ namespace dnGREP.WPF
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(CopySearchToReplaceCommand), "Main_CopySearchForToReplaceWith", string.Empty);
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(CopyReplaceToSearchCommand), "Main_CopyReplaceWithToSearchFor", string.Empty);
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(ShowLinesInContextCommand), "Main_ContextShowLines", string.Empty);
+            KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(ToggleDetailsViewCommand), "", string.Empty);
         }
 
         public MainViewModel()
@@ -866,6 +867,10 @@ namespace dnGREP.WPF
         private RelayCommand? showLinesInContextCommand;
         public RelayCommand ShowLinesInContextCommand => showLinesInContextCommand ??= new RelayCommand(
             _ => ShowLinesInContext = !ShowLinesInContext);
+
+        private RelayCommand? toggleDetailsViewCommand;
+        public RelayCommand ToggleDetailsViewCommand => toggleDetailsViewCommand ??= new RelayCommand(
+            _ => ToggleDetailsView());
 
         #endregion
 
@@ -3975,6 +3980,14 @@ namespace dnGREP.WPF
                     break;
             }
 
+        }
+
+        private void ToggleDetailsView()
+        {
+            bool enabled = GrepSettings.Instance.Get<bool>(GrepSettings.Key.TreeListViewEnabled);
+            GrepSettings.Instance.Set<bool>(GrepSettings.Key.TreeListViewEnabled, !enabled);
+
+            ResultsViewModel.RaiseSettingsPropertiesChanged();
         }
         #endregion
     }

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -108,7 +108,7 @@ namespace dnGREP.WPF
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(CopySearchToReplaceCommand), "Main_CopySearchForToReplaceWith", string.Empty);
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(CopyReplaceToSearchCommand), "Main_CopyReplaceWithToSearchFor", string.Empty);
             KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(ShowLinesInContextCommand), "Main_ContextShowLines", string.Empty);
-            KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(ToggleDetailsViewCommand), "", string.Empty);
+            KeyBindingManager.RegisterCommand(KeyCategory.Main, nameof(ToggleDetailsViewCommand), "Options_EnableDetailsViewInResultsTree", string.Empty);
         }
 
         public MainViewModel()
@@ -3985,7 +3985,7 @@ namespace dnGREP.WPF
         private void ToggleDetailsView()
         {
             bool enabled = GrepSettings.Instance.Get<bool>(GrepSettings.Key.TreeListViewEnabled);
-            GrepSettings.Instance.Set<bool>(GrepSettings.Key.TreeListViewEnabled, !enabled);
+            GrepSettings.Instance.Set(GrepSettings.Key.TreeListViewEnabled, !enabled);
 
             ResultsViewModel.RaiseSettingsPropertiesChanged();
         }


### PR DESCRIPTION
Introduce a new `ToggleDetailsViewCommand` in `MainViewModel` to toggle the `TreeListViewEnabled` setting. The command is registered with the `KeyBindingManager` and implemented using a `RelayCommand`. Added the `ToggleDetailsView` method to handle the setting toggle and notify the `ResultsViewModel` of changes.