### PR TITLE
Remove calls to prohibit using custom editors.

### DIFF
--- a/dnGREP.Engines/GenericPluginEngine.cs
+++ b/dnGREP.Engines/GenericPluginEngine.cs
@@ -399,10 +399,5 @@ namespace dnGREP.Engines
         {
             //Do nothing
         }
-
-        public override void OpenFile(OpenFileArgs args)
-        {
-            Utils.OpenFile(args);
-        }
     }
 }

--- a/dnGREP.OpenXmlEngine/GrepEngineOpenXml.cs
+++ b/dnGREP.OpenXmlEngine/GrepEngineOpenXml.cs
@@ -462,12 +462,6 @@ namespace dnGREP.Engines.OpenXml
             //Do nothing
         }
 
-        public override void OpenFile(OpenFileArgs args)
-        {
-            args.UseCustomEditor = false;
-            Utils.OpenFile(args);
-        }
-
         [GeneratedRegex(@"(.+)_([0-9a-fA-F]{64})")]
         private static partial Regex CacheFileNameRegex();
 

--- a/dnGREP.PdfEngine/GrepEnginePdf.cs
+++ b/dnGREP.PdfEngine/GrepEnginePdf.cs
@@ -427,10 +427,5 @@ namespace dnGREP.Engines.Pdf
         {
             //Do nothing
         }
-
-        public override void OpenFile(OpenFileArgs args)
-        {
-            Utils.OpenFile(args);
-        }
     }
 }

--- a/dnGREP.WordEngine/GrepEngineWord.cs
+++ b/dnGREP.WordEngine/GrepEngineWord.cs
@@ -323,12 +323,6 @@ namespace dnGREP.Engines.Word
 
         public Version? FrameworkVersion => Assembly.GetAssembly(typeof(IGrepEngine))?.GetName()?.Version;
 
-        public override void OpenFile(OpenFileArgs args)
-        {
-            args.UseCustomEditor = false;
-            Utils.OpenFile(args);
-        }
-
         #region Private Members
         /// <summary>
         /// Loads Microsoft Word.


### PR DESCRIPTION
Changed OpenXML and Word plugins - was not allowed when there was just one custom editor, presumably a text editor. Clean up overrides that just re-implement the base class.