### PR TITLE
Add confirmation dialog for MRU item removal

### DIFF
--- a/dnGREP.Common/GrepApplicationSettings.cs
+++ b/dnGREP.Common/GrepApplicationSettings.cs
@@ -400,6 +400,8 @@ namespace dnGREP.Common
             public const string TreeListViewColumnOrder = "TreeListViewColumnOrder";
             [DefaultValue("22,150,200,200,100,100,100,160,100")]
             public const string TreeListViewColumnWidths = "TreeListViewColumnWidths";
+            [DefaultValue(true)]
+            public const string ConfirmRemoveMRUItems = "ConfirmRemoveMRUItems";
         }
 
         public static class ObsoleteKey

--- a/dnGREP.Localization/Properties/Resources.Designer.cs
+++ b/dnGREP.Localization/Properties/Resources.Designer.cs
@@ -4437,6 +4437,15 @@ namespace dnGREP.Localization.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do not ask me again when removing recent items.
+        /// </summary>
+        public static string MessageBox_DoNotAskMeAgainWhenRemovingRecentItems {
+            get {
+                return ResourceManager.GetString("MessageBox_DoNotAskMeAgainWhenRemovingRecentItems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do not show this message again.
         /// </summary>
         public static string MessageBox_DoNotShowThisMessageAgain {
@@ -4622,6 +4631,24 @@ namespace dnGREP.Localization.Properties {
         public static string MessageBox_PluginErrors {
             get {
                 return ResourceManager.GetString("MessageBox_PluginErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        public static string MessageBox_Remove {
+            get {
+                return ResourceManager.GetString("MessageBox_Remove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove item &quot;{0}&quot; from this list?.
+        /// </summary>
+        public static string MessageBox_RemoveItem0FromThisList {
+            get {
+                return ResourceManager.GetString("MessageBox_RemoveItem0FromThisList", resourceCulture);
             }
         }
         
@@ -5288,6 +5315,15 @@ namespace dnGREP.Localization.Properties {
         public static string Options_CompareCommand {
             get {
                 return ResourceManager.GetString("Options_CompareCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm when removing items from history lists.
+        /// </summary>
+        public static string Options_ConfirmWhenRemovingItemsFromHistoryLists {
+            get {
+                return ResourceManager.GetString("Options_ConfirmWhenRemovingItemsFromHistoryLists", resourceCulture);
             }
         }
         

--- a/dnGREP.Localization/Properties/Resources.resx
+++ b/dnGREP.Localization/Properties/Resources.resx
@@ -4632,4 +4632,20 @@ dnGrep "C:\Program Files\dnGrep" t\w*t</value>
     <value>Error message</value>
     <comment>Main window sort options menu label (accel)</comment>
   </data>
+  <data name="Options_ConfirmWhenRemovingItemsFromHistoryLists" xml:space="preserve">
+    <value>Confirm when removing items from history lists</value>
+    <comment>Options dialog, confirm remove checkbox label</comment>
+  </data>
+  <data name="MessageBox_Remove" xml:space="preserve">
+    <value>Remove</value>
+    <comment>Message box button text</comment>
+  </data>
+  <data name="MessageBox_DoNotAskMeAgainWhenRemovingRecentItems" xml:space="preserve">
+    <value>Do not ask me again when removing recent items</value>
+    <comment>Message box text for: history list do not ask again checkbox</comment>
+  </data>
+  <data name="MessageBox_RemoveItem0FromThisList" xml:space="preserve">
+    <value>Remove item "{0}" from this list?</value>
+    <comment>Message box text for: Remove from history list message: {0} is the item to remove</comment>
+  </data>
 </root>

--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -852,9 +852,9 @@ namespace dnGREP.WPF
             p => OpenAppLogsFolder(),
             q => true);
 
-        private RelayCommand? deleteMRUItemCommand;
-        public RelayCommand DeleteMRUItemCommand => deleteMRUItemCommand ??= new RelayCommand(
-            p => DeleteMRUItem(p as MRUViewModel),
+        private RelayCommand? removeMRUItemCommand;
+        public RelayCommand RemoveMRUItemCommand => removeMRUItemCommand ??= new RelayCommand(
+            p => RemoveMRUItem(p as MRUViewModel),
             q => true);
 
         private RelayCommand? filterComboBoxDropDownCommand;
@@ -3897,10 +3897,35 @@ namespace dnGREP.WPF
             }
         }
 
-        private void DeleteMRUItem(MRUViewModel? item)
+        private void RemoveMRUItem(MRUViewModel? item)
         {
             if (item != null)
             {
+                bool confirmRemove = GrepSettings.Instance.Get<bool>(GrepSettings.Key.ConfirmRemoveMRUItems);
+                if (confirmRemove)
+                {
+                    MessageBoxCustoms customs = new()
+                    {
+                        OKButtonText = Resources.MessageBox_Remove,
+                        DoNotAskAgainCheckboxText = Resources.MessageBox_DoNotAskMeAgainWhenRemovingRecentItems,
+                        ShowDoNotAskAgainCheckbox = true,
+                    };
+                    var answer = CustomMessageBox.Show(TranslationSource.Format(Resources.MessageBox_RemoveItem0FromThisList, item.StringValue),
+                        Resources.MessageBox_DnGrep,
+                        MessageBoxButtonEx.OKCancel, MessageBoxImage.Question,
+                        MessageBoxResultEx.Cancel, customs,
+                        TranslationSource.Instance.FlowDirection);
+
+                    if (answer.Result == MessageBoxResultEx.Cancel)
+                    {
+                        return;
+                    }
+                    else if (answer.DoNotAskAgain)
+                    {
+                        GrepSettings.Instance.Set(GrepSettings.Key.ConfirmRemoveMRUItems, false);
+                    }
+                }
+
                 ObservableCollection<MRUViewModel>? list = null;
                 string? itemKey = null;
                 switch (item.ValueType)

--- a/dnGREP.WPF/ViewModels/OptionsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/OptionsViewModel.cs
@@ -478,6 +478,9 @@ namespace dnGREP.WPF
         private double matchThreshold;
 
         [ObservableProperty]
+        private bool confirmRemoveMRUItems;
+
+        [ObservableProperty]
         private int maxPathBookmarks;
 
         [ObservableProperty]
@@ -769,6 +772,7 @@ namespace dnGREP.WPF
                 ShowFileInfoTooltips != Settings.Get<bool>(GrepSettings.Key.ShowFileInfoTooltips) ||
                 MatchTimeout != Settings.Get<double>(GrepSettings.Key.MatchTimeout) ||
                 MatchThreshold != Settings.Get<double>(GrepSettings.Key.FuzzyMatchThreshold) ||
+                ConfirmRemoveMRUItems != Settings.Get<bool>(GrepSettings.Key.ConfirmRemoveMRUItems) ||
                 MaxSearchBookmarks != Settings.Get<int>(GrepSettings.Key.MaxSearchBookmarks) ||
                 MaxPathBookmarks != Settings.Get<int>(GrepSettings.Key.MaxPathBookmarks) ||
                 MaxExtensionBookmarks != Settings.Get<int>(GrepSettings.Key.MaxExtensionBookmarks) ||
@@ -1117,6 +1121,7 @@ namespace dnGREP.WPF
             ShowLinesInContext = Settings.Get<bool>(GrepSettings.Key.ShowLinesInContext);
             ContextLinesBefore = Settings.Get<int>(GrepSettings.Key.ContextLinesBefore);
             ContextLinesAfter = Settings.Get<int>(GrepSettings.Key.ContextLinesAfter);
+            ConfirmRemoveMRUItems = Settings.Get<bool>(GrepSettings.Key.ConfirmRemoveMRUItems);
             MaxSearchBookmarks = Settings.Get<int>(GrepSettings.Key.MaxSearchBookmarks);
             MaxPathBookmarks = Settings.Get<int>(GrepSettings.Key.MaxPathBookmarks);
             MaxExtensionBookmarks = Settings.Get<int>(GrepSettings.Key.MaxExtensionBookmarks);
@@ -1338,6 +1343,7 @@ namespace dnGREP.WPF
             Settings.Set(GrepSettings.Key.ShowLinesInContext, ShowLinesInContext);
             Settings.Set(GrepSettings.Key.ContextLinesBefore, ContextLinesBefore);
             Settings.Set(GrepSettings.Key.ContextLinesAfter, ContextLinesAfter);
+            Settings.Set(GrepSettings.Key.ConfirmRemoveMRUItems, ConfirmRemoveMRUItems);
             Settings.Set(GrepSettings.Key.MaxSearchBookmarks, MaxSearchBookmarks);
             Settings.Set(GrepSettings.Key.MaxPathBookmarks, MaxPathBookmarks);
             Settings.Set(GrepSettings.Key.MaxExtensionBookmarks, MaxExtensionBookmarks);

--- a/dnGREP.WPF/Views/MainView.xaml
+++ b/dnGREP.WPF/Views/MainView.xaml
@@ -72,7 +72,7 @@
                               IsChecked="{Binding IsPinned, Mode=TwoWay}"/>
                 <Button Grid.Column="3" Margin="3,0"
                         Style="{StaticResource ComboBoxDeleteButton}"
-                        Command="{Binding DataContext.DeleteMRUItemCommand,
+                        Command="{Binding DataContext.RemoveMRUItemCommand,
                             RelativeSource={RelativeSource AncestorType=ComboBox}}"
                         CommandParameter="{Binding}"/>
             </Grid>

--- a/dnGREP.WPF/Views/OptionsView.xaml
+++ b/dnGREP.WPF/Views/OptionsView.xaml
@@ -1007,6 +1007,8 @@
 
                 <GroupBox Header="{l:Loc Key='Options_HistoryLists'}">
                     <StackPanel>
+                        <CheckBox Margin="3" Content="{l:Loc Key='Options_ConfirmWhenRemovingItemsFromHistoryLists'}"
+                                  IsChecked="{Binding ConfirmRemoveMRUItems}" />
                         <StackPanel Orientation="Horizontal">
                             <TextBox Margin="3,0"
                                      Text="{Binding MaxPathBookmarks, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
Added a user setting to confirm before removing items from MRU history lists, with a corresponding checkbox in the Options dialog. Updated MainViewModel to show a customizable confirmation dialog with a "do not ask again" option. Introduced new localized resources for dialog text. Renamed DeleteMRUItemCommand to RemoveMRUItemCommand and updated all references. Synced the new setting between OptionsViewModel and GrepSettings. Updated OptionsView UI to support the new feature.