### PR TITLE
Remove Encoding.CodePages package from WPF project

### DIFF
--- a/dnGREP.WPF/dnGREP.WPF.csproj
+++ b/dnGREP.WPF/dnGREP.WPF.csproj
@@ -213,7 +213,6 @@
     <PackageReference Include="NLog">
       <Version>6.1.4</Version>
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Page Remove="Properties\DesignTimeResources.xaml" />


### PR DESCRIPTION
The System.Text.Encoding.CodePages NuGet package as it is already included in the .net runtime. Remove the explicit reference, but keep the assembly in the setup.