### PR TITLE
Optimize font family loading with async prewarming

### DIFF
--- a/dnGREP.WPF/ViewModels/MainViewModel.cs
+++ b/dnGREP.WPF/ViewModels/MainViewModel.cs
@@ -174,6 +174,8 @@ namespace dnGREP.WPF
 
                 GrepSearchResultsViewModel.SearchResultsMessenger.Register<SortColumnRequest>(
                     "SortColumn", OnSortColumnRequested);
+
+                System.Threading.Tasks.Task.Run(OptionsViewModel.PrewarmFontFamilies);
             }
         }
 

--- a/dnGREP.WPF/ViewModels/OptionsViewModel.cs
+++ b/dnGREP.WPF/ViewModels/OptionsViewModel.cs
@@ -206,12 +206,14 @@ namespace dnGREP.WPF
             }
         }
 
-        public static IList<FontInfo> FontFamilies
+        private static readonly Lazy<IList<FontInfo>> s_fontFamilies = new(
+            () => [.. Fonts.SystemFontFamilies.Select(r => new FontInfo(r.Source)).OrderBy(r => r.FamilyName)]);
+
+        public static IList<FontInfo> FontFamilies => s_fontFamilies.Value;
+
+        public static void PrewarmFontFamilies()
         {
-            get
-            {
-                return [.. Fonts.SystemFontFamilies.Select(r => new FontInfo(r.Source)).OrderBy(r => r.FamilyName)];
-            }
+            _ = FontFamilies;
         }
 
         public static IList<FontWeight> FontWeightList


### PR DESCRIPTION
Added async prewarming of font families in MainViewModel to improve startup performance. Refactored OptionsViewModel to cache font families using Lazy<IList<FontInfo>>, reducing repeated allocations. Introduced a static PrewarmFontFamilies method for explicit cache initialization and updated the FontFamilies property to return the cached list.